### PR TITLE
definition provider - abstraction and implementation

### DIFF
--- a/dnWalker.Tests/TypeSystem/DefinitionProviderTests.cs
+++ b/dnWalker.Tests/TypeSystem/DefinitionProviderTests.cs
@@ -1,0 +1,32 @@
+﻿using dnWalker.TypeSystem;
+
+using FluentAssertions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace dnWalker.Tests.TypeSystem
+{
+    public class DefinitionProviderTests
+    {
+        const string ExamplesAssembly_net48 = @"..\..\..\..\Examples\bin\Release\net5.0\Examples.dll";
+        const string ExamplesAssembly_net50 = @"..\..\..\..\Examples\bin\Release\framework\Examples.Framework.exe";
+
+        [Theory]
+        [InlineData(ExamplesAssembly_net48)]
+        [InlineData(ExamplesAssembly_net50)]
+        public void Test_DefinitionProviderResolves_TextWriter(string location)
+        {
+
+            IDefinitionContext definitionLoader = DefinitionContext.LoadFromFile(location);
+            DefinitionProvider definitionProvider = new DefinitionProvider(definitionLoader);
+
+            definitionProvider.GetTypeDefinition("System.IO.TextWriter").Should().NotBeNull();
+        }
+    }
+}

--- a/dnWalker/DataElement.Helpers.cs
+++ b/dnWalker/DataElement.Helpers.cs
@@ -1,0 +1,122 @@
+﻿using dnlib.DotNet;
+
+using dnWalker.TypeSystem;
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MMC.Data
+{
+    public static class DataElement
+    {
+        public static IDataElement CreateDataElement<T>(T value, IDefinitionProvider definitionProvider)
+        {
+            return CreateDataElement((object)value, definitionProvider);
+        }
+
+        public static IDataElement CreateDataElement(object value, IDefinitionProvider definitionProvider)
+        {
+            if (value is null)
+            {
+                return ObjectReference.Null;
+            }
+
+            var type = value.GetType();
+            if (type.IsArray)
+            {
+                var array = value as Array;
+                return new ArrayOf(array, definitionProvider.GetTypeDefinition(type.GetElementType().FullName));
+            }
+
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Boolean: return new Int4((Boolean)value ? 1 : 0);
+                case TypeCode.Char: return new Int4((Char)value);
+                case TypeCode.SByte: return new Int4((SByte)value);
+                case TypeCode.Byte: return new Int4((Byte)value);
+                case TypeCode.Int16: return new Int4((Int16)value);
+                case TypeCode.UInt16: return new UnsignedInt4((UInt16)value);
+                case TypeCode.Int32: return new Int4((Int32)value);
+                case TypeCode.UInt32: return new UnsignedInt4((UInt32)value);
+                case TypeCode.Int64: return new Int8((Int64)value);
+                case TypeCode.UInt64: return new UnsignedInt8((UInt64)value);
+                case TypeCode.Single: return new Float4((Single)value);
+                case TypeCode.Double: return new Float8((Double)value);
+                case TypeCode.String: return new ConstantString(value.ToString());
+                default:
+                    if (value is IntPtr ip)
+                    {
+                        return IntPtr.Size == 4 ? CreateDataElement(ip.ToInt32(), definitionProvider) : CreateDataElement(ip.ToInt64(), definitionProvider);
+                    }
+                    if (value is UIntPtr up)
+                    {
+                        return IntPtr.Size == 4 ? CreateDataElement(up.ToUInt32(), definitionProvider) : CreateDataElement(up.ToUInt64(), definitionProvider);
+                    }
+
+                    // TODO: handle reference & complex types...
+                    var typeName = type.FullName;
+
+                    var typeDef = definitionProvider.GetTypeDefinition(typeName);
+
+                    //throw new NotSupportedException("CreateDataElement for " + value.GetType());
+                    return ObjectReference.Null;
+            }
+        }
+
+        public static IDataElement GetNullValue(TypeSig typeSig)
+        {
+            if (!typeSig.IsPrimitive)
+            {
+                return ObjectReference.Null;
+            }
+
+            if (typeSig.Module.CorLibTypes.IntPtr == typeSig
+                || typeSig.Module.CorLibTypes.Boolean == typeSig
+                || typeSig.Module.CorLibTypes.Char == typeSig
+                || typeSig.Module.CorLibTypes.Int16 == typeSig
+                || typeSig.Module.CorLibTypes.Int32 == typeSig
+                || typeSig.Module.CorLibTypes.SByte == typeSig
+                || typeSig.Module.CorLibTypes.Byte == typeSig)
+            {
+                return Int4.Zero;
+            }
+
+            if (typeSig.Module.CorLibTypes.Single == typeSig)
+            {
+                return Float4.Zero;
+            }
+
+            if (typeSig.Module.CorLibTypes.Double == typeSig)
+            {
+                return Float8.Zero;
+            }
+
+            if (typeSig.Module.CorLibTypes.UInt16 == typeSig
+                || typeSig.Module.CorLibTypes.UInt32 == typeSig)
+            {
+                return UnsignedInt4.Zero;
+            }
+
+            if (typeSig.Module.CorLibTypes.Int64 == typeSig)
+            {
+                return Int8.Zero;
+            }
+
+            if (typeSig.Module.CorLibTypes.UInt64 == typeSig)
+            {
+                return UnsignedInt8.Zero;
+            }
+
+            if (typeSig.Module.CorLibTypes.UIntPtr == typeSig)
+            {
+                return UnsignedInt8.Zero;
+            }
+
+            throw new NotSupportedException("GetNullValue for " + typeSig.FullName);
+        }
+    }
+}

--- a/dnWalker/TypeSystem/DefinitionContext.cs
+++ b/dnWalker/TypeSystem/DefinitionContext.cs
@@ -1,0 +1,114 @@
+﻿using dnlib.DotNet;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace dnWalker.TypeSystem
+{
+    public class DefinitionContext : IDefinitionContext
+    {
+        private readonly ModuleContext _moduleContext = ModuleDef.CreateModuleContext();
+
+        private readonly Dictionary<string, ModuleDef> _loadedModules = new Dictionary<string, ModuleDef>();
+        private readonly Dictionary<string, AssemblyDef> _loadedAssemblies = new Dictionary<string, AssemblyDef>();
+        private ModuleDef _mainModule;
+
+        private DefinitionContext()
+        {
+
+        }
+
+        public ModuleDef MainModule
+        {
+            get { return _mainModule; }
+        }
+
+        public ModuleContext ModuleContext
+        {
+            get { return _moduleContext; }
+        }
+
+        public IReadOnlyCollection<ModuleDef> Modules
+        {
+            get
+            {
+                return _loadedModules.Values;
+            }
+        }
+
+        public IReadOnlyCollection<AssemblyDef> Assemblies
+        {
+            get
+            {
+                return _loadedAssemblies.Values;
+            }
+        }
+
+        private void Setup(ModuleDef module)
+        {
+            string moduleName = module.FullName;
+            if (_loadedModules.ContainsKey(moduleName))
+            {
+                return;
+            }
+
+            _loadedModules.Add(moduleName, module);
+
+            // load the referenced assemblies
+            foreach (AssemblyDef refAssembly in module.GetAssemblyRefs().Select(ar => _moduleContext.AssemblyResolver.ResolveThrow(ar, module)))
+            {
+                Setup(refAssembly);
+            }
+        }
+
+        private void Setup(AssemblyDef assembly)
+        {
+            string assemblyName = assembly.FullName;
+            if (_loadedAssemblies.ContainsKey(assemblyName))
+            {
+                return;
+            }
+
+            _loadedAssemblies.Add(assemblyName, assembly);
+
+            foreach (ModuleDef module in assembly.Modules)
+            {
+                Setup(module);
+            }
+        }
+
+        private void SetupMain(AssemblyDef mainAssembly)
+        {
+            _mainModule = mainAssembly.ManifestModule;
+            Setup(mainAssembly);
+        }
+
+        public static DefinitionContext LoadFromFile(string file)
+        {
+            DefinitionContext definitionContext = new DefinitionContext();
+            AssemblyDef mainAssembly = AssemblyDef.Load(file, definitionContext._moduleContext);
+            definitionContext.SetupMain(mainAssembly);
+
+
+            return definitionContext;
+        }
+
+        public static DefinitionContext LoadFromAppDomain(Assembly loadedAssembly)
+        {
+            return LoadFromAppDomain(loadedAssembly.ManifestModule);
+        }
+
+        public static DefinitionContext LoadFromAppDomain(Module loadedModule)
+        {
+            DefinitionContext definitionContext = new DefinitionContext();
+
+            AssemblyDef mainAssembly = ModuleDefMD.Load(loadedModule, definitionContext._moduleContext).Assembly;
+            definitionContext.SetupMain(mainAssembly);
+            return definitionContext;
+        }
+    }
+}

--- a/dnWalker/TypeSystem/DefinitionProvider.cs
+++ b/dnWalker/TypeSystem/DefinitionProvider.cs
@@ -1,0 +1,396 @@
+﻿using dnlib.DotNet;
+
+using MMC.Data;
+using MMC.State;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace dnWalker.TypeSystem
+{
+    public class DefinitionProvider : IDefinitionProvider
+    {
+        private class TypeSigEqualityComparer : IEqualityComparer<TypeSig>
+        {
+            private readonly SigComparer _sigComparer = new SigComparer();
+
+            public bool Equals(TypeSig x, TypeSig y)
+            {
+                return _sigComparer.Equals(x, y);
+            }
+
+            public int GetHashCode([DisallowNull] TypeSig obj)
+            {
+                return obj.GetHashCode();
+            }
+        }
+
+        private class BaseTypesInternal : IBaseTypes
+        {
+            private readonly DefinitionProvider _definitionProvider;
+            private readonly ICorLibTypes _corLibTypes;
+
+            public BaseTypesInternal(DefinitionProvider definitionProvider, ICorLibTypes corLibTypes)
+            {
+                _definitionProvider = definitionProvider ?? throw new ArgumentNullException(nameof(definitionProvider));
+                _corLibTypes = corLibTypes ?? throw new ArgumentNullException(nameof(corLibTypes));
+
+                Thread = definitionProvider.GetTypeDefinition("System.Threading.Thread").ToTypeSig().ToTypeDefOrRefSig();
+                Delegate = definitionProvider.GetTypeDefinition("System.Delegate").ToTypeSig();
+                Exception = definitionProvider.GetTypeDefinition("System.Exception").ToTypeSig().ToTypeDefOrRefSig();
+            }
+
+            public TypeRef GetTypeRef(string @namespace, string name)
+            {
+                return _corLibTypes.GetTypeRef(@namespace, name);
+            }
+
+            public CorLibTypeSig Void
+            {
+                get
+                {
+                    return _corLibTypes.Void;
+                }
+            }
+
+            public CorLibTypeSig Boolean
+            {
+                get
+                {
+                    return _corLibTypes.Boolean;
+                }
+            }
+
+            public CorLibTypeSig Char
+            {
+                get
+                {
+                    return _corLibTypes.Char;
+                }
+            }
+
+            public CorLibTypeSig SByte
+            {
+                get
+                {
+                    return _corLibTypes.SByte;
+                }
+            }
+
+            public CorLibTypeSig Byte
+            {
+                get
+                {
+                    return _corLibTypes.Byte;
+                }
+            }
+
+            public CorLibTypeSig Int16
+            {
+                get
+                {
+                    return _corLibTypes.Int16;
+                }
+            }
+
+            public CorLibTypeSig UInt16
+            {
+                get
+                {
+                    return _corLibTypes.UInt16;
+                }
+            }
+
+            public CorLibTypeSig Int32
+            {
+                get
+                {
+                    return _corLibTypes.Int32;
+                }
+            }
+
+            public CorLibTypeSig UInt32
+            {
+                get
+                {
+                    return _corLibTypes.UInt32;
+                }
+            }
+
+            public CorLibTypeSig Int64
+            {
+                get
+                {
+                    return _corLibTypes.Int64;
+                }
+            }
+
+            public CorLibTypeSig UInt64
+            {
+                get
+                {
+                    return _corLibTypes.UInt64;
+                }
+            }
+
+            public CorLibTypeSig Single
+            {
+                get
+                {
+                    return _corLibTypes.Single;
+                }
+            }
+
+            public CorLibTypeSig Double
+            {
+                get
+                {
+                    return _corLibTypes.Double;
+                }
+            }
+
+            public CorLibTypeSig String
+            {
+                get
+                {
+                    return _corLibTypes.String;
+                }
+            }
+
+            public CorLibTypeSig TypedReference
+            {
+                get
+                {
+                    return _corLibTypes.TypedReference;
+                }
+            }
+
+            public CorLibTypeSig IntPtr
+            {
+                get
+                {
+                    return _corLibTypes.IntPtr;
+                }
+            }
+
+            public CorLibTypeSig UIntPtr
+            {
+                get
+                {
+                    return _corLibTypes.UIntPtr;
+                }
+            }
+
+            public CorLibTypeSig Object
+            {
+                get
+                {
+                    return _corLibTypes.Object;
+                }
+            }
+
+            public TypeDefOrRefSig Thread
+            {
+                get;
+            }
+            public TypeSig Delegate { get; }
+            public TypeDefOrRefSig Exception { get; }
+
+            public AssemblyRef AssemblyRef
+            {
+                get
+                {
+                    return _corLibTypes.AssemblyRef;
+                }
+            }
+        }
+
+
+        private readonly IDefinitionContext _definitionContext;
+        
+        private readonly Dictionary<string, TypeDef> _typeCache;
+        private readonly Dictionary<string, int> _sizeCache;
+        //private readonly Dictionary<TypeSig, List<ITypeDefOrRef>> _inheritenceCache = new Dictionary<TypeSig, List<ITypeDefOrRef>>();
+        private readonly Dictionary<string, MethodDef> _methodCache = new Dictionary<string, MethodDef>();
+        private readonly BaseTypesInternal _baseTypes;
+
+        public DefinitionProvider(IDefinitionContext definitionContext)
+        {
+            _definitionContext = definitionContext;
+            _typeCache = BuildTypeCache(definitionContext.MainModule);
+            _sizeCache = BuildSizeCache(definitionContext.MainModule);
+
+            _baseTypes = new BaseTypesInternal(this, definitionContext.MainModule.CorLibTypes);
+
+            // dirty, dirty trick
+            AllocatedDelegate.DelegateTypeDef = GetTypeDefinition("System.Delegate");
+        }
+
+        private static Dictionary<string, TypeDef> BuildTypeCache(ModuleDef module)
+        { 
+            Dictionary<string, TypeDef> typeCache = new Dictionary<string, TypeDef>();
+
+            foreach (var typeDef in module.Types)
+            {
+                CacheType(typeDef);
+            }
+
+            ICorLibTypes corLibTypes = module.CorLibTypes;
+            CacheType(corLibTypes.Void.TypeDef);
+            CacheType(corLibTypes.Boolean.TypeDef);
+            CacheType(corLibTypes.Char.TypeDef);
+            CacheType(corLibTypes.SByte.TypeDef);
+            CacheType(corLibTypes.Byte.TypeDef);
+            CacheType(corLibTypes.Int16.TypeDef);
+            CacheType(corLibTypes.UInt16.TypeDef);
+            CacheType(corLibTypes.Int32.TypeDef);
+            CacheType(corLibTypes.UInt32.TypeDef);
+            CacheType(corLibTypes.Int64.TypeDef);
+            CacheType(corLibTypes.UInt64.TypeDef);
+            CacheType(corLibTypes.Single.TypeDef);
+            CacheType(corLibTypes.Double.TypeDef);
+            CacheType(corLibTypes.String.TypeDef);
+            CacheType(corLibTypes.TypedReference.TypeDef);
+            CacheType(corLibTypes.IntPtr.TypeDef);
+            CacheType(corLibTypes.UInt64.TypeDef);
+            CacheType(corLibTypes.Object.TypeDef);
+
+            void CacheType(TypeDef type)
+            {
+                if (type == null) return;
+
+                typeCache[type.FullName] = type;
+            }
+
+
+            return typeCache;
+        }
+
+        private static Dictionary<string, int> BuildSizeCache(ModuleDef module)
+        {
+            Dictionary<string, int> sizeCache = new Dictionary<string, int>();
+
+            ICorLibTypes corLibTypes = module.CorLibTypes;
+
+            sizeCache[corLibTypes.Boolean.FullName] = sizeof(bool);
+            sizeCache[corLibTypes.Char.FullName] = sizeof(char);
+            sizeCache[corLibTypes.SByte.FullName] = sizeof(sbyte);
+            sizeCache[corLibTypes.Byte.FullName] = sizeof(byte);
+            sizeCache[corLibTypes.Int16.FullName] = sizeof(short);
+            sizeCache[corLibTypes.UInt16.FullName] = sizeof(ushort);
+            sizeCache[corLibTypes.Int32.FullName] = sizeof(int);
+            sizeCache[corLibTypes.UInt32.FullName] = sizeof(uint);
+            sizeCache[corLibTypes.Int64.FullName] = sizeof(long);
+            sizeCache[corLibTypes.UInt64.FullName] = sizeof(ulong);
+            sizeCache[corLibTypes.Single.FullName] = sizeof(float);
+            sizeCache[corLibTypes.Double.FullName] = sizeof(double);
+            sizeCache[corLibTypes.IntPtr.FullName] = IntPtr.Size;
+            sizeCache[corLibTypes.UIntPtr.FullName] = UIntPtr.Size;
+
+            return sizeCache;
+        }
+
+
+        public TypeDef GetTypeDefinition(string fullTypeName)
+        {
+            if (_typeCache.TryGetValue(fullTypeName, out var type))
+            {
+                return type;
+            }
+
+            // naive, very naive implementation
+            foreach (TypeDef t in _definitionContext.Modules.SelectMany(m => m.Types))
+            {
+                if (t.FullName == fullTypeName)
+                {
+                    _typeCache[t.FullName] = t;
+                    return t;
+                }
+            }
+
+            throw new TypeNotFoundException(fullTypeName);
+        }
+        public MethodDef GetMethodDefinition(string fullMethodName)
+        {
+            if (_methodCache.TryGetValue(fullMethodName, out var method))
+            {
+                return method;
+            }
+
+            int lastDot = fullMethodName.LastIndexOf(".");
+            string methodTypeName = fullMethodName.Substring(0, lastDot);
+
+            TypeDef typeDef = GetTypeDefinition(methodTypeName);
+
+            string methodName = fullMethodName.Substring(lastDot + 1);
+            method = typeDef.FindMethod(methodName);
+
+            _methodCache[fullMethodName] = method;
+
+            return method;
+        }
+
+        public IBaseTypes BaseTypes
+        {
+            get
+            {
+                return _baseTypes;
+            }
+        }
+
+        public int SizeOf(TypeSig type)
+        {
+            if (_sizeCache.TryGetValue(type.FullName, out var size))
+            {
+                return size;
+            }
+
+            throw new TypeNotSupportForSize(type.FullName);
+        }
+
+        //public IEnumerable<ITypeDefOrRef> InheritanceEnumerator(ITypeDefOrRef type)
+        //{
+        //    static List<ITypeDefOrRef> BuildInheritenceChain(ITypeDefOrRef type)
+        //    {
+        //        List<ITypeDefOrRef> chain = new List<ITypeDefOrRef>();
+
+        //        var currentType = type;
+        //        do
+        //        {
+        //            var currentTypeDef = currentType.ResolveTypeDefThrow();
+        //            if (currentTypeDef == null)
+        //            {
+        //                break;
+        //            }
+        //            chain.Add(currentTypeDef);
+        //            currentType = currentTypeDef.BaseType;
+        //        } while (currentType != null);
+
+        //        return chain;
+        //    }
+
+        //    TypeSig typeSig = type.ToTypeSig();
+        //    if (_inheritenceCache.TryGetValue(typeSig, out var inheritenceChain))
+        //    {
+        //        return inheritenceChain;
+        //    }
+
+        //    inheritenceChain = BuildInheritenceChain(type);
+
+        //    _inheritenceCache.Add(typeSig, inheritenceChain);
+        //    return inheritenceChain;
+        //}
+
+        public IDefinitionContext Context
+        {
+            get
+            {
+                return _definitionContext;
+            }
+        }
+    }
+}

--- a/dnWalker/TypeSystem/DnLibExtensions.cs
+++ b/dnWalker/TypeSystem/DnLibExtensions.cs
@@ -1,0 +1,58 @@
+﻿using dnlib.DotNet;
+
+using System;
+using System.Collections.Generic;
+
+namespace dnWalker.TypeSystem
+{
+    public static class DnLibExtensions
+    {
+        public static IEnumerable<ITypeDefOrRef> InheritanceEnumerator(this ITypeDefOrRef type)
+        {
+            var currentType = type;
+            do
+            {
+                var currentTypeDef = currentType.ResolveTypeDefThrow();
+                if (currentTypeDef == null)
+                {
+                    break;
+                }
+                yield return currentTypeDef;
+                currentType = currentTypeDef.BaseType;
+            } while (currentType != null);
+        }
+
+        public static bool TryGetTypeHandle(this ITypeDefOrRef typeRef, out RuntimeTypeHandle typeHandle)
+        {
+            TypeSig corLibType = typeRef.Module.CorLibTypes.GetCorLibTypeSig(typeRef);
+            if (corLibType != null)
+            {
+                if (corLibType == typeRef.Module.CorLibTypes.String)
+                {
+                    typeHandle = typeof(string).TypeHandle;
+                    return true;
+                }
+            }
+
+            typeHandle = default(RuntimeTypeHandle);
+            return false;
+        }
+
+        public static int GetFieldOffset(this FieldDef field)
+        {
+            if (field.FieldOffset.HasValue) return (int)field.FieldOffset.Value;
+
+            IList<FieldDef> fields = field.DeclaringType.Fields;
+            for (int i = 0; i < fields.Count; i++)
+            {
+                if (fields[i] == field)
+                {
+                    field.FieldOffset = (uint)i;
+                    return i;
+                }
+            }
+
+            throw new TypeSystemException($"Could not determine the field offset for field: {field}");
+        }
+    }
+}

--- a/dnWalker/TypeSystem/IDefinitionContext.cs
+++ b/dnWalker/TypeSystem/IDefinitionContext.cs
@@ -1,0 +1,23 @@
+﻿using dnlib.DotNet;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace dnWalker.TypeSystem
+{
+    /// <summary>
+    /// Loads the assemblies and modules.
+    /// </summary>
+    public interface IDefinitionContext
+    {
+        IReadOnlyCollection<ModuleDef> Modules { get; }
+        IReadOnlyCollection<AssemblyDef> Assemblies { get; }
+        ModuleDef MainModule { get; }
+        ModuleContext ModuleContext { get; }
+    }
+
+
+}

--- a/dnWalker/TypeSystem/IDefinitionProvider.cs
+++ b/dnWalker/TypeSystem/IDefinitionProvider.cs
@@ -1,0 +1,109 @@
+﻿using dnlib.DotNet;
+
+using MMC.Data;
+using MMC.State;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace dnWalker.TypeSystem
+{
+    /// <summary>
+    /// Provides the type and method definitions.
+    /// </summary>
+    public interface IDefinitionProvider
+    {
+        IDefinitionContext Context { get; }
+
+        TypeDef GetTypeDefinition(string fullTypeName);
+
+        MethodDef GetMethodDefinition(string fullMethodName);
+
+        int SizeOf(TypeSig type);
+
+        IBaseTypes BaseTypes { get; }
+
+        //IEnumerable<ITypeDefOrRef> InheritanceEnumerator(ITypeDefOrRef type);
+    }
+
+    public interface IBaseTypes : ICorLibTypes
+    {
+        TypeDefOrRefSig Thread { get; }
+        TypeDefOrRefSig Exception { get; }
+        TypeSig Delegate { get; }
+    }
+
+    public static class DefinitionProviderExtensions
+    {
+        public static bool IsSubtype(this IDefinitionProvider definitionProvider, ITypeDefOrRef subType, ITypeDefOrRef superType)
+        {
+            SigComparer sigComparer = new SigComparer();
+            
+            TypeSig superSig = superType.ToTypeSig();
+
+            foreach (ITypeDefOrRef tr in subType.InheritanceEnumerator())
+            {
+                if (sigComparer.Equals(tr.ToTypeSig(), superSig))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static MethodDef FindVirtualMethod(this ExplicitActiveState cur, MethodDef method, IDataElement dataElement)
+        {
+            const string VirtualMethodLookupKey = "virtual-methods";
+
+            dataElement = dataElement is IManagedPointer ptr ? ptr.Value : dataElement;
+
+            if (!(dataElement is ObjectReference reference))
+            {
+                throw new NotSupportedException($"ObjectReference expected, '{dataElement?.GetType().FullName}' found.");
+            }
+            
+            (MethodSig sig, string name) key = (method.MethodSig, method.Name);
+
+            if (!cur.PathStore.CurrentPath.TryGetObjectAttribute(dataElement, VirtualMethodLookupKey, out Dictionary<(MethodSig, string), MethodDef> lookup))
+            {
+                lookup = new Dictionary<(MethodSig, string), MethodDef>();
+                cur.PathStore.CurrentPath.SetObjectAttribute(dataElement, VirtualMethodLookupKey, lookup);
+            }
+
+            if (!lookup.TryGetValue(key, out MethodDef result))
+            {
+                AllocatedObject ao = (AllocatedObject)cur.DynamicArea.Allocations[reference];
+                ITypeDefOrRef type = ao.Type;
+
+                foreach (ITypeDefOrRef superType in type.InheritanceEnumerator())
+                {
+                    TypeDef superTypeDef = superType.ResolveTypeDefThrow();
+                    MethodDef candidate = superTypeDef.FindMethod(method.Name, key.sig);
+
+                    if (candidate != null && 
+                        candidate.Body != null && 
+                        candidate.Body.Instructions.Count > 0)
+                    {
+                        result = candidate;
+                        break;
+                    }
+                }
+
+                if (result != null)
+                {
+                    lookup[key] = result;
+                }
+                else
+                {
+                    throw new MemberNotFoundException(type.FullName, key.name);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/dnWalker/TypeSystem/TypeSystemException.cs
+++ b/dnWalker/TypeSystem/TypeSystemException.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace dnWalker.TypeSystem
+{
+    public class TypeSystemException : Exception
+    {
+        public TypeSystemException()
+        {
+        }
+
+        public TypeSystemException(string message) : base(message)
+        {
+        }
+
+        public TypeSystemException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected TypeSystemException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+
+    public class TypeException : TypeSystemException
+    {
+        public TypeException()
+        {
+        }
+
+        public TypeException(string typeName)
+        {
+            _typeName = typeName;
+        }
+
+        protected TypeException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            _typeName = info.GetString(nameof(TypeName));
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(TypeName), _typeName);
+        }
+
+
+        private readonly string _typeName;
+
+        public override string Message
+        {
+            get
+            {
+                return $"Could not find the '{_typeName}'.";
+            }
+        }
+
+        public string TypeName
+        {
+            get
+            {
+                return _typeName;
+            }
+        }
+    }
+
+    public class TypeNotFoundException : TypeException
+    {
+        public TypeNotFoundException()
+        {
+        }
+
+        public TypeNotFoundException(string typeName) : base(typeName)
+        {
+        }
+
+        protected TypeNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+
+    public class TypeNotSupportForSize : TypeException
+    {
+        public TypeNotSupportForSize()
+        {
+        }
+
+        public TypeNotSupportForSize(string typeName) : base(typeName)
+        {
+        }
+
+        protected TypeNotSupportForSize(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+
+    public class MemberNotFoundException : TypeException
+    {
+        public MemberNotFoundException()
+        {
+        }
+
+        public MemberNotFoundException(string typeName, string memberName) : base(typeName)
+        {
+            MemberName = memberName;
+        }
+
+        protected MemberNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            MemberName = info.GetString(nameof(MemberName));
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(MemberName), MemberName);
+        }
+
+        public string MemberName { get; }
+    }
+}


### PR DESCRIPTION
definition provider jak je imlementovaný v https://github.com/kfrajtak/dnWalker/blob/fb88274bb9a76612ef9efb275606a5846f8cfbf4/dnWalker/DefinitionLookup.cs dělá mnoho zbytečných věcí (třeba konverzi z `ITypeDefOrRef `již implementuje dnlib přes extension metodu `ResolveTypeDef `a `ResolveTypeDefThrow`) a taky některá jeho funkcionalita je závislá na `MMC.Data` (`SearchVirtualMethod`) a záslost by měla být obráceně.

- zbytečné metody (`GetFieldDefinition` atp, které již dělá dnlib) jsou odebrány a na svých místech se volají přímo nad dnlib
- jiné metody (třeba `InheritanceEnumerator`) jsou předělány jako extension metody přímo nad dnlib typy (soubor DnLibExtensions.cs)
- `DataElement` factory metody (`CreateDataElement` a `GetNullValue`) jsou předělané v souboru DataElement.Static.cs. Pro jejich spuštění je sice potřeba mít referenci na `IDefinitionProvider`, ale je tam volnější propojení.
- jedním z cílů bylo odebrat všechny výrazy typu `type.FullName == "System.Object"`, takže `IDefinitionProvider` přímo nabízí základní typy přes `BaseTypes`. Bohužel se to ne všude podařilo, například u size lookup - původně měl být klíč `TypeSig`, který ale nefungoval, takže se to vrátilo na `FullName`
- `AssemblyLoader` má poměrně složitý a kód (s různým cachingem atp), takže jsem jej předělal přes `IDefinitionContext`. Ten aktivně resoluje a cachuje všechny referencované assembly podobným způsobem jako `AssemblyLoader`, jenom je ukládá do `Dictionary` a nepoužívá `ModuleContext.AssemblyResolver.Cache`. Nevím přesně proč, ale nyní funguje načítání jak kódu zkomilovaného pro net4.8 tak pro net5.0 (což předtím pro AssemblyLoader nefungovalo)