### PR TITLE
Bugfix/sep logic refequality implication

### DIFF
--- a/dnWalker.Z3/RefEqualityCollector.cs
+++ b/dnWalker.Z3/RefEqualityCollector.cs
@@ -9,13 +9,13 @@ using System.Threading.Tasks;
 
 namespace dnWalker.Z3
 {
-    public class RefEqualityCollector : ExpressionVisitor<ICollection<(IMemberVariable v1, IMemberVariable v2)>>
+    public class RefEqualityCollector : ExpressionVisitor<ICollection<(IVariable v1, IVariable v2)>>
     {
         public static readonly RefEqualityCollector Instance = new RefEqualityCollector();
 
-        public static ICollection<(IMemberVariable v1, IMemberVariable v2)> GetRefEqualities(IEnumerable<Expression> expressions)
+        public static ICollection<(IVariable v1, IVariable v2)> GetRefEqualities(IEnumerable<Expression> expressions)
         {
-            HashSet<(IMemberVariable v1, IMemberVariable v2)> refEqualities = new HashSet<(IMemberVariable v1, IMemberVariable v2)>();
+            HashSet<(IVariable v1, IVariable v2)> refEqualities = new HashSet<(IVariable v1, IVariable v2)>();
 
             foreach (Expression expression in expressions)
             {
@@ -25,12 +25,12 @@ namespace dnWalker.Z3
             return refEqualities;
         }
 
-        public static void GetRefEqualities(Expression expression, ICollection<(IMemberVariable v1, IMemberVariable v2)> refEqualities)
+        public static void GetRefEqualities(Expression expression, ICollection<(IVariable v1, IVariable v2)> refEqualities)
         {
             Instance.Visit(expression, refEqualities);
         }
 
-        protected override Expression VisitBinary(BinaryExpression binary, ICollection<(IMemberVariable v1, IMemberVariable v2)> context)
+        protected override Expression VisitBinary(BinaryExpression binary, ICollection<(IVariable v1, IVariable v2)> context)
         {
             if (binary.Operator == Operator.Equal &&
                 binary.Left is VariableExpression leftVarExpr &&
@@ -40,11 +40,7 @@ namespace dnWalker.Z3
                 IVariable lVar = leftVarExpr.Variable;
                 IVariable rVar = rightVarExpr.Variable;
 
-                if (lVar is IMemberVariable lMemVar &&
-                    rVar is IMemberVariable rMemVar)
-                {
-                    context.Add((lMemVar, rMemVar));
-                }
+                context.Add((lVar, rVar));
 
                 return binary;
             }

--- a/dnWalker.Z3/Z3Solver.Model.cs
+++ b/dnWalker.Z3/Z3Solver.Model.cs
@@ -20,7 +20,7 @@ namespace dnWalker.Z3
     public partial class Z3Solver
     {
 
-        private static IModel BuildModel(Constraint constraint, ref SolverContext context)
+        private static IModel BuildModel(Constraint constraint, SolverContext context)
         {
             Z3Model z3Model = context.Solver.Model;
             Model result = new Model(constraint);

--- a/dnWalker.Z3/Z3Solver.Translator.cs
+++ b/dnWalker.Z3/Z3Solver.Translator.cs
@@ -18,7 +18,7 @@ namespace dnWalker.Z3
         /// </summary>
         /// <param name="constraint"></param>
         /// <param name="context"></param>
-        private static void AssertPureTerms(Constraint constraint, ref SolverContext context)
+        private static void AssertPureTerms(Constraint constraint, SolverContext context)
         {
             Z3ExpressionTranslator translator = new Z3ExpressionTranslator(
                 context.Z3,

--- a/dnWalker.Z3/Z3Solver.Types.cs
+++ b/dnWalker.Z3/Z3Solver.Types.cs
@@ -27,7 +27,7 @@ namespace dnWalker.Z3
         /// This method sorts the reference type variables into groups per their type and enforces non equality.
         /// TODO: make it accept inheritance.
         /// </remarks>
-        private static void AssertTypes(Constraint constraint, ref SolverContext context)
+        private static void AssertTypes(Constraint constraint, SolverContext context)
         {
             Dictionary<IVariable, Expr> varLookup = context.VariableMapping;
             Dictionary<TypeSig, List<IVariable>> groups = new Dictionary<TypeSig, List<IVariable>>(TypeEqualityComparer.Instance);

--- a/dnWalker.Z3/Z3Solver.Variables.cs
+++ b/dnWalker.Z3/Z3Solver.Variables.cs
@@ -18,16 +18,16 @@ namespace dnWalker.Z3
 {
     public partial class Z3Solver
     {
-        private static void SetupVariableMapping(Constraint constraint, ref SolverContext context)
+        private static void SetupVariableMapping(Constraint constraint, SolverContext context)
         {
             foreach (IVariable variable in GatherVariables(constraint))
             {
-                Expr varExpr = CreateVariableExpression(variable.Type, ref context);
+                Expr varExpr = CreateVariableExpression(variable.Type, context);
                 context.VariableMapping[variable] = varExpr;
             }
 
 
-            static void AddVarConstraint(ArithExpr var, long min, long max, ref SolverContext context)
+            static void AddVarConstraint(ArithExpr var, long min, long max, SolverContext context)
             {
                 BoolExpr constraint = context.Z3.MkAnd(
                     context.Z3.MkGe(var, context.Z3.MkInt(min)),
@@ -35,7 +35,7 @@ namespace dnWalker.Z3
                 context.Solver.Assert(constraint);
             }
 
-            static Expr CreateVariableExpression(TypeSig type, ref SolverContext context)
+            static Expr CreateVariableExpression(TypeSig type, SolverContext context)
             {
                 if (type.IsPrimitive)
                 {
@@ -44,49 +44,49 @@ namespace dnWalker.Z3
                     if (type.IsByte())
                     {
                         ArithExpr varExpr = context.Z3.MkIntConst(context.Symbol());
-                        AddVarConstraint(varExpr, byte.MinValue, byte.MaxValue, ref context);
+                        AddVarConstraint(varExpr, byte.MinValue, byte.MaxValue, context);
                         return varExpr;
                     }
                     if (type.IsUInt16())
                     {
                         ArithExpr varExpr = context.Z3.MkIntConst(context.Symbol());
-                        AddVarConstraint(varExpr, ushort.MinValue, ushort.MaxValue, ref context);
+                        AddVarConstraint(varExpr, ushort.MinValue, ushort.MaxValue, context);
                         return varExpr;
                     }
                     if (type.IsUInt32())
                     {
                         ArithExpr varExpr = context.Z3.MkIntConst(context.Symbol());
-                        AddVarConstraint(varExpr, uint.MinValue, uint.MaxValue, ref context);
+                        AddVarConstraint(varExpr, uint.MinValue, uint.MaxValue, context);
                         return varExpr;
                     }
                     if (type.IsUInt64())
                     {
                         ArithExpr varExpr = context.Z3.MkIntConst(context.Symbol());
-                        AddVarConstraint(varExpr, 0, long.MaxValue, ref context);
+                        AddVarConstraint(varExpr, 0, long.MaxValue, context);
                         return varExpr;
                     }
                     if (type.IsSByte())
                     {
                         ArithExpr varExpr = context.Z3.MkIntConst(context.Symbol());
-                        AddVarConstraint(varExpr, sbyte.MinValue, sbyte.MaxValue, ref context);
+                        AddVarConstraint(varExpr, sbyte.MinValue, sbyte.MaxValue, context);
                         return varExpr;
                     }
                     if (type.IsInt16())
                     {
                         ArithExpr varExpr = context.Z3.MkIntConst(context.Symbol());
-                        AddVarConstraint(varExpr, short.MinValue, short.MaxValue, ref context);
+                        AddVarConstraint(varExpr, short.MinValue, short.MaxValue, context);
                         return varExpr;
                     }
                     if (type.IsInt32())
                     {
                         ArithExpr varExpr = context.Z3.MkIntConst(context.Symbol());
-                        AddVarConstraint(varExpr, int.MinValue, int.MaxValue, ref context);
+                        AddVarConstraint(varExpr, int.MinValue, int.MaxValue, context);
                         return varExpr;
                     }
                     if (type.IsInt64())
                     {
                         ArithExpr varExpr = context.Z3.MkIntConst(context.Symbol());
-                        AddVarConstraint(varExpr, long.MinValue, long.MaxValue, ref context);
+                        AddVarConstraint(varExpr, long.MinValue, long.MaxValue, context);
                         return varExpr;
                     }
                     if (type.IsSingle()) return context.Z3.MkRealConst(context.Symbol());


### PR DESCRIPTION
opraveno problematické použití separační logiky 
původní formule ((x1.field = v1) && (x2.field = v2) && (v1 = v2)) => (x1 = x2) 
správná formule (x1 = x2) => (x1.field == x2.field)