### PR TITLE
user model - XML input + tests

### DIFF
--- a/dnWalker.Symbolic/Heap/IReadOnlyObjectHeapNode.cs
+++ b/dnWalker.Symbolic/Heap/IReadOnlyObjectHeapNode.cs
@@ -25,6 +25,7 @@ namespace dnWalker.Symbolic.Heap
         /// <param name="invocation"></param>
         /// <returns></returns>
         IValue GetMethodResult(IMethod method, int invocation);
+        bool TryGetMethodResult(IMethod method, int invocation, [NotNullWhen(true)] out IValue? value);
 
         IEnumerable<IField> Fields { get; }
         IEnumerable<(IMethod method, int invocation)> MethodInvocations { get; }

--- a/dnWalker.Symbolic/Heap/ObjectHeapNode.cs
+++ b/dnWalker.Symbolic/Heap/ObjectHeapNode.cs
@@ -93,5 +93,10 @@ namespace dnWalker.Symbolic.Heap
         {
             return _fields.TryGetValue(field, out value);
         }
+
+        public bool TryGetMethodResult(IMethod method, int invocation, [NotNullWhen(true)] out IValue? value)
+        {
+            return _methods.TryGetValue((method, invocation), out value);
+        }
     }
 }

--- a/dnWalker.Symbolic/StringValue.cs
+++ b/dnWalker.Symbolic/StringValue.cs
@@ -9,7 +9,7 @@ namespace dnWalker.Symbolic
     public readonly struct StringValue : IValue, IEquatable<StringValue>
     {
         public static readonly StringValue Null = new StringValue(null);
-        public static readonly StringValue Empty = new StringValue("");
+        public static readonly StringValue Empty = new StringValue(String.Empty);
 
         public StringValue(string? content)
         {
@@ -55,6 +55,7 @@ namespace dnWalker.Symbolic
 
         public static StringValue Parse(string text)
         {
+            if (text == null) return Null;
             if (text == "\"\"") return Empty;
             if (text == "null") return Null;
             return new StringValue(text.Trim('"'));

--- a/dnWalker.Symbolic/ValueFactory.cs
+++ b/dnWalker.Symbolic/ValueFactory.cs
@@ -82,5 +82,84 @@ namespace dnWalker.Symbolic
         {
             return new PrimitiveValue<T>(value);
         }
+
+
+        public static IValue? ParseValue(string literal, TypeSig type)
+        {
+            if (string.IsNullOrEmpty(literal)) return GetDefault(type);
+
+            IValue? value = null;
+
+            if (type.IsString())
+            {
+                value = StringValue.Parse(literal);
+            }
+            else if (type.IsBoolean())
+            {
+                value = new PrimitiveValue<bool>(bool.Parse(literal));
+            }
+            else if (type.IsChar())
+            {
+                value = new PrimitiveValue<char>(literal[0]);
+            }
+            else if (type.IsByte())
+            {
+                value = new PrimitiveValue<byte>(byte.Parse(literal));
+            }
+            else if (type.IsUInt16())
+            {
+                value = new PrimitiveValue<ushort>(ushort.Parse(literal));
+            }
+            else if (type.IsUInt32())
+            {
+                value = new PrimitiveValue<uint>(uint.Parse(literal));
+            }
+            else if (type.IsUInt64())
+            {
+                value = new PrimitiveValue<ulong>(ulong.Parse(literal));
+            }
+            else if (type.IsSByte())
+            {
+                value = new PrimitiveValue<sbyte>(sbyte.Parse(literal));
+            }
+            else if (type.IsInt16())
+            {
+                value = new PrimitiveValue<short>(short.Parse(literal));
+            }
+            else if (type.IsInt32())
+            {
+                value = new PrimitiveValue<int>(int.Parse(literal));
+            }
+            else if (type.IsInt64())
+            {
+                value = new PrimitiveValue<long>(long.Parse(literal));
+            }
+            else if (type.IsSingle())
+            {
+                if (literal == "-INF") value = new PrimitiveValue<float>(float.NegativeInfinity);
+                else if (literal == "+INF") value = new PrimitiveValue<float>(float.PositiveInfinity);
+                else if (literal == "NAN") value = new PrimitiveValue<float>(float.NaN);
+                else value = new PrimitiveValue<float>(float.Parse(literal));
+            }
+            else if (type.IsDouble())
+            {
+                if (literal == "-INF") value = new PrimitiveValue<double>(double.NegativeInfinity);
+                else if (literal == "+INF") value = new PrimitiveValue<double>(double.PositiveInfinity);
+                else if (literal == "NAN") value = new PrimitiveValue<double>(double.NaN);
+                else value = new PrimitiveValue<double>(double.Parse(literal));
+            }
+
+            else if (!type.IsPrimitive)
+            {
+                if (literal == null || literal == "null") value = Location.Null;
+                else
+                {
+                    throw new NotSupportedException("Non primitive non strings literals can only be null");
+                }
+            }
+
+            return value;
+        }
+
     }
 }

--- a/dnWalker.Tests/DnlibTestBase.cs
+++ b/dnWalker.Tests/DnlibTestBase.cs
@@ -18,10 +18,25 @@ namespace dnWalker.Tests
         private readonly ITestOutputHelper _textOutput;
         private readonly IDefinitionProvider _definitionProvider;
 
+        /// <summary>
+        /// Initializes the <see cref="DnlibTestBase.DefinitionProvider"/> using entry assembly specified by <paramref name="assemblyFileName"/>.
+        /// </summary>
+        /// <param name="textOutput"></param>
+        /// <param name="assemblyFileName"></param>
         protected DnlibTestBase(ITestOutputHelper textOutput, string assemblyFileName)
         {
             _textOutput = textOutput;
             _definitionProvider = new DefinitionProvider(Domain.LoadFromFile(assemblyFileName));
+        }
+
+        /// <summary>
+        /// Initializes the <see cref="DnlibTestBase.DefinitionProvider"/> using the calling assembly as the entry assembly.
+        /// </summary>
+        /// <param name="textOutput"></param>
+        protected DnlibTestBase(ITestOutputHelper textOutput)
+        {
+            _textOutput = textOutput;
+            _definitionProvider = new DefinitionProvider(Domain.LoadFromAppDomain(System.Reflection.Assembly.GetCallingAssembly()));
         }
 
         protected TypeDef GetType(string ns, string typeName)

--- a/dnWalker.Tests/Input/UserArrayTests.cs
+++ b/dnWalker.Tests/Input/UserArrayTests.cs
@@ -1,0 +1,161 @@
+﻿using dnlib.DotNet;
+
+using dnWalker.Input;
+using dnWalker.Symbolic;
+using dnWalker.Symbolic.Heap;
+
+using FluentAssertions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit.Abstractions;
+
+namespace dnWalker.Tests.Input
+{
+    public class UserArrayTests : DnlibTestBase
+    {
+        public UserArrayTests(ITestOutputHelper textOutput) : base(textOutput)
+        {
+        }
+
+        [Fact]
+        public void BuildEmptyArray()
+        {
+            TypeSig elementType = DefinitionProvider.BaseTypes.String;
+
+            UserArray array = new UserArray() { ElementType = elementType };
+
+            Model model = new Model();
+            Dictionary<string, IValue> references = new Dictionary<string, IValue>();
+
+            IValue result = array.Build(model, null, references);
+            result.Should().BeOfType<Location>();
+            result.Should().NotBe(Location.Null);
+
+            Location location = (Location)result;
+
+            model.HeapInfo.TryGetNode(location, out IHeapNode? arrayNode).Should().BeTrue();
+            ((IArrayHeapNode)arrayNode!).Length.Should().Be(0);
+        }
+
+        [Theory]
+        [InlineData("x", "y", "z")]
+        [InlineData("x", null, "z")]
+        [InlineData(null, null, null, null)]
+        public void BuildArray(params string[] elements)
+        {
+            TypeSig elementType = DefinitionProvider.BaseTypes.String;
+
+            UserArray array = new UserArray() { ElementType = elementType };
+            int length = 0;
+            for (int i = 0; i < elements.Length; ++i)
+            {
+                if (elements[i] != null)
+                {
+                    array.Elements[i] = new UserLiteral(elements[i]);
+                    length = i + 1;
+                }
+            }
+
+            Model model = new Model();
+            Dictionary<string, IValue> references = new Dictionary<string, IValue>();
+
+            IValue result = array.Build(model, null, references);
+            result.Should().BeOfType<Location>();
+            result.Should().NotBe(Location.Null);
+
+            Location location = (Location)result;
+
+            model.HeapInfo.TryGetNode(location, out IHeapNode? node).Should().BeTrue();
+            IArrayHeapNode arrayNode = (IArrayHeapNode)node!;
+
+            arrayNode.Length.Should().Be(length);
+            for (int i = 0; i < elements.Length; ++i)
+            {
+                if (elements[i] != null)
+                {
+                    arrayNode.TryGetElement(i, out IValue? value).Should().BeTrue();
+                    value.Should().BeOfType<StringValue>();
+                    StringValue strVal = (StringValue)value!;
+
+                    strVal.Content.Should().Be(elements[i]);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("x", "y", "z")]
+        public void BuildArrayUsingExpectedType(params string[] elements)
+        {
+            TypeSig elementType = DefinitionProvider.BaseTypes.String;
+
+            UserArray array = new UserArray() { ElementType = elementType };
+            int length = 0;
+            for (int i = 0; i < elements.Length; ++i)
+            {
+                if (elements[i] != null)
+                {
+                    array.Elements[i] = new UserLiteral(elements[i]);
+                    length = i + 1;
+                }
+            }
+
+            Model model = new Model();
+            Dictionary<string, IValue> references = new Dictionary<string, IValue>();
+
+            IValue result = array.Build(model, new SZArraySig(elementType), references);
+            result.Should().BeOfType<Location>();
+            result.Should().NotBe(Location.Null);
+
+            Location location = (Location)result;
+
+            model.HeapInfo.TryGetNode(location, out IHeapNode? node).Should().BeTrue();
+            IArrayHeapNode arrayNode = (IArrayHeapNode)node!;
+
+            arrayNode.Length.Should().Be(length);
+            for (int i = 0; i < elements.Length; ++i)
+            {
+                if (elements[i] != null)
+                {
+                    arrayNode.TryGetElement(i, out IValue? value).Should().BeTrue();
+                    value.Should().BeOfType<StringValue>();
+                    StringValue strVal = (StringValue)value!;
+
+                    strVal.Content.Should().Be(elements[i]);
+                }
+            }
+        }
+
+
+        [Theory]
+        [InlineData("x", "y", "z")]
+        public void BuildNamedArray(params string[] elements)
+        {
+            TypeSig elementType = DefinitionProvider.BaseTypes.String;
+
+            string name = "myArray";
+
+            UserArray array = new UserArray() { ElementType = elementType, Id = name };
+            int length = 0;
+            for (int i = 0; i < elements.Length; ++i)
+            {
+                if (elements[i] != null)
+                {
+                    array.Elements[i] = new UserLiteral(elements[i]);
+                    length = i + 1;
+                }
+            }
+
+            Model model = new Model();
+            Dictionary<string, IValue> references = new Dictionary<string, IValue>();
+
+            IValue result = array.Build(model, null, references);
+
+            references.Should().Contain(KeyValuePair.Create(name, result));
+        }
+    }
+}

--- a/dnWalker.Tests/Input/UserLiteralTests.cs
+++ b/dnWalker.Tests/Input/UserLiteralTests.cs
@@ -1,0 +1,329 @@
+﻿using dnWalker.Input;
+using dnWalker.Symbolic;
+
+using FluentAssertions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit.Abstractions;
+
+namespace dnWalker.Tests.Input
+{
+    public class UserLiteralTests : DnlibTestBase
+    {
+        // missing BuildNamed*** Tests
+
+        public UserLiteralTests(ITestOutputHelper textOutput) : base(textOutput)
+        {
+        }
+
+        [Theory]
+        [InlineData("some not null or empty literal")]
+        public void BuildLiteralWithouExpectedType(string literalValue)
+        {
+            UserLiteral literal = new UserLiteral(literalValue) { Type = DefinitionProvider.BaseTypes.String};
+            IValue value = literal.Build(new Model(), null, new Dictionary<string, IValue>());
+
+            value.Should().Be(new StringValue(literalValue));
+        }
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData(null)]
+        [InlineData("")]
+        public void BuildNullString(string literalValue)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.String, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<StringValue>();
+            value.Should().Be(StringValue.Null);
+        }
+
+        [Theory]
+        [InlineData("\"\"")]
+        public void BuildEmptyString(string literalValue)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.String, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<StringValue>();
+            value.Should().Be(StringValue.Empty);
+        }
+
+        [Theory]
+        [InlineData("\"hello world\"")]
+        [InlineData("hello world\"")]
+        [InlineData("\"hello world")]
+        public void BuildNonEmptyString(string literalValue)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.String, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<StringValue>();
+            value.Should().Be(new StringValue(literalValue.Trim('"')));
+        }
+
+        [Theory]
+        [InlineData("\"hello world\"", "myString")]
+        [InlineData("hello world\"", "myString")]
+        [InlineData("\"hello world", "myString")]
+        public void BuildNamedString(string literalValue, string name)
+        {
+            Dictionary<string, IValue> references = new Dictionary<string, IValue>();
+            UserLiteral literal = new UserLiteral(literalValue) { Id = name};
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.String, references);
+
+            references.Should().ContainKey(name);
+            references[name].Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("true", true)]
+        [InlineData("false", false)]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        public void BuildBoolean(string literalValue, bool expected)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.Boolean, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<PrimitiveValue<bool>>();
+            value.Should().Be(new PrimitiveValue<bool>(expected));
+        }
+
+        [Theory]
+        [InlineData("true", true, "mybool")]
+        public void BuildNamedBoolean(string literalValue, bool expected, string name)
+        {
+            Dictionary<string, IValue> references = new Dictionary<string, IValue>();
+            UserLiteral literal = new UserLiteral(literalValue) { Id = name };
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.Boolean, references);
+
+            references.Should().ContainKey(name);
+            references[name].Should().Be(value);
+        }
+
+
+        [Theory]
+        [InlineData("A", 'A')]
+        [InlineData(null, default(char))]
+        [InlineData("", default(char))]
+        public void BuildChar(string literalValue, char expected)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.Char, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<PrimitiveValue<char>>();
+            value.Should().Be(new PrimitiveValue<char>(expected));
+        }
+
+        [Theory]
+        [InlineData("A", 'A', "myChar")]
+        public void BuildNamedChar(string literalValue, char expected, string name)
+        {
+            Dictionary<string, IValue> references = new Dictionary<string, IValue>();
+            UserLiteral literal = new UserLiteral(literalValue) { Id = name };
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.Char, references);
+
+            references.Should().ContainKey(name);
+            references[name].Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("0", byte.MinValue)]
+        [InlineData("255", byte.MaxValue)]
+        [InlineData(null, 0)]
+        [InlineData("", 0)]
+        public void BuildByte(string literalValue, byte expected)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.Byte, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<PrimitiveValue<byte>>();
+            value.Should().Be(new PrimitiveValue<byte>(expected));
+        }
+
+        [Theory]
+        [InlineData("128", 128, "myByte")]
+        public void BuildNamedByte(string literalValue, byte expected, string name)
+        {
+            Dictionary<string, IValue> references = new Dictionary<string, IValue>();
+            UserLiteral literal = new UserLiteral(literalValue) { Id = name };
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.Byte, references);
+
+            references.Should().ContainKey(name);
+            references[name].Should().Be(value);
+        }
+
+
+        [Theory]
+        [InlineData("0", ushort.MinValue)]
+        [InlineData("65535", ushort.MaxValue)]
+        [InlineData(null, 0)]
+        [InlineData("", 0)]
+        public void BuildUInt16(string literalValue, ushort expected)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.UInt16, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<PrimitiveValue<ushort>>();
+            value.Should().Be(new PrimitiveValue<ushort>(expected));
+        }
+
+        [Theory]
+        [InlineData("0", uint.MinValue)]
+        [InlineData("4294967295", uint.MaxValue)]
+        [InlineData(null, 0)]
+        [InlineData("", 0)]
+        public void BuildUInt32(string literalValue, uint expected)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.UInt32, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<PrimitiveValue<uint>>();
+            value.Should().Be(new PrimitiveValue<uint>(expected));
+        }
+
+        [Theory]
+        [InlineData("0", ulong.MinValue)]
+        [InlineData("18446744073709551615", ulong.MaxValue)]
+        [InlineData(null, 0)]
+        [InlineData("", 0)]
+        public void BuildUInt64(string literalValue, ulong expected)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.UInt64, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<PrimitiveValue<ulong>>();
+            value.Should().Be(new PrimitiveValue<ulong>(expected));
+        }
+
+        [Theory]
+        [InlineData("-128", sbyte.MinValue)]
+        [InlineData("127", sbyte.MaxValue)]
+        [InlineData(null, 0)]
+        [InlineData("", 0)]
+        public void BuildSByte(string literalValue, sbyte expected)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.SByte, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<PrimitiveValue<sbyte>>();
+            value.Should().Be(new PrimitiveValue<sbyte>(expected));
+        }
+
+        [Theory]
+        [InlineData("-32768", short.MinValue)]
+        [InlineData("32767", short.MaxValue)]
+        [InlineData(null, 0)]
+        [InlineData("", 0)]
+        public void BuildInt16(string literalValue, short expected)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.Int16, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<PrimitiveValue<short>>();
+            value.Should().Be(new PrimitiveValue<short>(expected));
+        }
+
+        [Theory]
+        [InlineData("-2147483648", int.MinValue)]
+        [InlineData("2147483647", int.MaxValue)]
+        [InlineData(null, 0)]
+        [InlineData("", 0)]
+        public void BuildInt32(string literalValue, int expected)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.Int32, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<PrimitiveValue<int>>();
+            value.Should().Be(new PrimitiveValue<int>(expected));
+        }
+
+        [Theory]
+        [InlineData("-9223372036854775808", long.MinValue)]
+        [InlineData("9223372036854775807", long.MaxValue)]
+        [InlineData(null, 0)]
+        [InlineData("", 0)]
+        public void BuildInt64(string literalValue, long expected)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.Int64, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<PrimitiveValue<long>>();
+            value.Should().Be(new PrimitiveValue<long>(expected));
+        }
+
+        [Theory]
+        [InlineData("-3.40282347E+38", float.MinValue)]
+        [InlineData("3.40282347E+38", float.MaxValue)]
+        [InlineData(null, 0)]
+        [InlineData("", 0)]
+        public void BuildSingle(string literalValue, float expected)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.Single, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<PrimitiveValue<float>>();
+            value.Should().Be(new PrimitiveValue<float>(expected));
+        }
+
+        [Theory]
+        [InlineData("-1.7976931348623157E+308", double.MinValue)]
+        [InlineData("1.7976931348623157E+308", double.MaxValue)]
+        [InlineData(null, 0)]
+        [InlineData("", 0)]
+        public void BuildDouble(string literalValue, double expected)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.Double, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<PrimitiveValue<double>>();
+            value.Should().Be(new PrimitiveValue<double>(expected));
+        }
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData(null)]
+        [InlineData("")]
+        public void BuildNullObject(string literalValue)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            IValue value = literal.Build(new Model(), DefinitionProvider.BaseTypes.Object, new Dictionary<string, IValue>());
+
+            value.Should().NotBeNull();
+            value.Should().BeOfType<Location>();
+            value.Should().Be(Location.Null);
+        }
+
+        [Theory]
+        [InlineData("something which is not null or empty string")]
+        public void BuildNonNullObject(string literalValue)
+        {
+            UserLiteral literal = new UserLiteral(literalValue);
+            Action act = () => literal.Build(new Model(), DefinitionProvider.BaseTypes.Object, new Dictionary<string, IValue>());
+
+            act.Should().Throw<NotSupportedException>();
+        }
+    }
+}

--- a/dnWalker.Tests/Input/UserModelTests.cs
+++ b/dnWalker.Tests/Input/UserModelTests.cs
@@ -1,0 +1,177 @@
+﻿using dnlib.DotNet;
+
+using dnWalker.Input;
+using dnWalker.Symbolic;
+using dnWalker.Symbolic.Heap;
+
+using FluentAssertions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit.Abstractions;
+
+namespace dnWalker.Tests.Input
+{
+    public class UserModelTests : DnlibTestBase
+    {
+        public class TestClass
+        {
+            public TestClass? Other;
+
+            public int Field;
+            public string? Property { get; }
+            public bool Method() { return false; }
+
+            public static string StaticField = "hello world";
+
+            public void TestMethod(int intArg, int[] arrayArg, string strArg)
+            {
+
+            }
+        }
+
+        private readonly TypeDef TestTypeDef;
+        private readonly TypeSig TestTypeSig;
+        private readonly MethodDef TestMethod;
+
+        public UserModelTests(ITestOutputHelper textOutput) : base(textOutput)
+        {
+            TestTypeDef = DefinitionProvider.GetTypeDefinition("dnWalker.Tests.Input.UserModelTests/TestClass");
+            TestTypeSig = TestTypeDef.ToTypeSig();
+            TestMethod = TestTypeDef.FindMethod(nameof(TestClass.TestMethod));
+        }
+
+
+        [Fact]
+        public void BuildEmpty()
+        {
+            UserModel userModel = new UserModel();
+
+            IModel model = userModel.Build();
+
+            model.IsEmpty().Should().BeTrue();
+        }
+
+        [Fact]
+        public void BuildWithStatidFields()
+        {
+            const string StaticFieldValue = "\"static field value\"";
+
+            UserModel userModel = new UserModel();
+
+            FieldDef staticField = TestTypeDef.FindField(nameof(TestClass.StaticField));
+            userModel.StaticFields[staticField] = new UserLiteral(StaticFieldValue);
+
+            IModel model = userModel.Build();
+
+            model.IsEmpty().Should().BeFalse();
+            model.TryGetValue(Variable.StaticField(staticField), out IValue? value).Should().BeTrue();
+            ((StringValue)value!).Content.Should().Be(StaticFieldValue.Trim('"'));
+        }
+
+        [Fact]
+        public void BuildWithMethodArgs()
+        {
+            const int IntArgValue = -111;
+
+            UserModel userModel = new UserModel();
+            Parameter intArgParameter = TestMethod.Parameters.First(p => p.Name == "intArg");
+            userModel.MethodArguments[intArgParameter] = new UserLiteral(IntArgValue.ToString());
+
+            IModel model = userModel.Build();
+
+            model.IsEmpty().Should().BeFalse();
+            model.TryGetValue(Variable.MethodArgument(intArgParameter), out IValue? value).Should().BeTrue();
+            ((PrimitiveValue<int>)value!).Value.Should().Be(IntArgValue);
+        }
+
+        [Fact]
+        public void BuildWithMethodArgsAndStaticFields()
+        {
+            const string StaticFieldValue = "\"static field value\"";
+            const int IntArgValue = -111;
+
+            UserModel userModel = new UserModel();
+
+            FieldDef staticField = TestTypeDef.FindField(nameof(TestClass.StaticField));
+            userModel.StaticFields[staticField] = new UserLiteral(StaticFieldValue);
+
+            Parameter intArgParameter = TestMethod.Parameters.First(p => p.Name == "intArg");
+            userModel.MethodArguments[intArgParameter] = new UserLiteral(IntArgValue.ToString());
+
+
+            IModel model = userModel.Build();
+
+            model.IsEmpty().Should().BeFalse();
+            model.TryGetValue(Variable.StaticField(staticField), out IValue? value).Should().BeTrue();
+            ((StringValue)value!).Content.Should().Be(StaticFieldValue.Trim('"'));
+
+            model.TryGetValue(Variable.MethodArgument(intArgParameter), out value).Should().BeTrue();
+            ((PrimitiveValue<int>)value!).Value.Should().Be(IntArgValue);
+        }
+
+        [Fact]
+        public void BuildWithMethodArgsAndStaticFieldsAndTopLevelReferences()
+        {
+            const string StaticFieldValue = "\"static field value\"";
+            const int IntArgValue = -111;
+
+            UserModel userModel = new UserModel();
+
+            userModel.Data["MyString"] = new UserLiteral(StaticFieldValue) { Type = DefinitionProvider.BaseTypes.String };
+            userModel.Data["MyIntArray"] = new UserLiteral(null) { Type = new SZArraySig(DefinitionProvider.BaseTypes.Int32) };
+
+            FieldDef staticField = TestTypeDef.FindField(nameof(TestClass.StaticField));
+            userModel.StaticFields[staticField] = new UserReference("MyString");
+
+            Parameter intArgParameter = TestMethod.Parameters.First(p => p.Name == "intArg");
+            userModel.MethodArguments[intArgParameter] = new UserLiteral(IntArgValue.ToString());
+
+            Parameter arrayArgParameter = TestMethod.Parameters.First(p => p.Name == "arrayArg");
+            userModel.MethodArguments[arrayArgParameter] = new UserReference("MyIntArray");
+
+
+            IModel model = userModel.Build();
+
+            model.IsEmpty().Should().BeFalse();
+            model.TryGetValue(Variable.StaticField(staticField), out IValue? value).Should().BeTrue();
+            ((StringValue)value!).Content.Should().Be(StaticFieldValue.Trim('"'));
+
+            model.TryGetValue(Variable.MethodArgument(intArgParameter), out value).Should().BeTrue();
+            ((PrimitiveValue<int>)value!).Value.Should().Be(IntArgValue);
+
+            model.TryGetValue(Variable.MethodArgument(arrayArgParameter), out value).Should().BeTrue();
+            ((Location)value!).Should().Be(Location.Null);
+        }
+
+        [Fact]
+        public void BuildWithMethodArgsAndStaticFieldsAndUpstreamReferences()
+        {
+
+            UserModel userModel = new UserModel();
+
+            FieldDef otherField = TestTypeDef.FindField(nameof(TestClass.Other));
+            Parameter thisArg = TestMethod.Parameters[0];
+
+            UserObject theInstance = new UserObject { Id = "thisInstance" };
+            theInstance.Fields[otherField] = new UserReference("thisInstance");
+
+            userModel.MethodArguments[thisArg] = theInstance;
+
+            IModel model = userModel.Build();
+
+            model.TryGetValue(Variable.MethodArgument(thisArg), out IValue? value).Should().BeTrue();
+            Location thisLocation = (Location)value!;
+
+            model.HeapInfo.TryGetNode(thisLocation, out IHeapNode? node).Should().BeTrue();
+            IObjectHeapNode objectNode = (IObjectHeapNode)node!;
+
+            objectNode.TryGetField(otherField, out value).Should().BeTrue();
+            value.Should().Be(thisLocation);
+        }
+    }
+}

--- a/dnWalker.Tests/Input/UserObjectTests.cs
+++ b/dnWalker.Tests/Input/UserObjectTests.cs
@@ -1,0 +1,210 @@
+﻿using dnlib.DotNet;
+
+using dnWalker.Input;
+using dnWalker.Symbolic;
+using dnWalker.Symbolic.Heap;
+
+using FluentAssertions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit.Abstractions;
+
+namespace dnWalker.Tests.Input
+{
+    public class UserObjectTests : DnlibTestBase
+    {
+        public class TestClass
+        {
+            public int Field;
+            public string? Property { get; }
+            public bool Method() { return false; }
+        }
+
+        private readonly TypeDef TestTypeDef;
+        private readonly TypeSig TestTypeSig;
+
+        public UserObjectTests(ITestOutputHelper textOutput) : base(textOutput)
+        {
+            TestTypeDef = DefinitionProvider.GetTypeDefinition("dnWalker.Tests.Input.UserObjectTests/TestClass");
+            TestTypeSig = TestTypeDef.ToTypeSig();
+        }
+
+        [Fact]
+        public void BuildEmptyObject()
+        {
+            TypeSig ts = TestTypeSig;
+
+            UserObject obj = new UserObject() { Type = ts };
+
+            Model model = new Model();
+
+            IValue value= obj.Build(model, null, new Dictionary<string, IValue>());
+
+            Location location = (Location)value;
+
+            location.Should().NotBe(Location.Null);
+
+            model.HeapInfo.TryGetNode(location, out IHeapNode? node).Should().BeTrue();
+            IObjectHeapNode objNode = (IObjectHeapNode)node!;
+
+            objNode.Type.Should().Be(ts);
+            objNode.Fields.Should().BeEmpty();
+            objNode.MethodInvocations.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void BuildEmptyObjectUsingExpectedType()
+        {
+            TypeSig ts = TestTypeSig;
+
+            UserObject obj = new UserObject();
+
+            Model model = new Model();
+
+            IValue value = obj.Build(model, ts, new Dictionary<string, IValue>());
+
+            Location location = (Location)value;
+
+            location.Should().NotBe(Location.Null);
+
+            model.HeapInfo.TryGetNode(location, out IHeapNode? node).Should().BeTrue();
+            IObjectHeapNode objNode = (IObjectHeapNode)node!;
+
+            objNode.Type.Should().Be(ts);
+            objNode.Fields.Should().BeEmpty();
+            objNode.MethodInvocations.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(5)]
+        public void BuildObjectWithFields(int fieldValue)
+        {
+            TypeSig ts = TestTypeSig;
+            TypeDef td = TestTypeDef;
+
+            FieldDef fd = td.FindField(nameof(TestClass.Field));
+
+            UserObject obj = new UserObject() { Type = ts };
+            obj.Fields[fd] = new UserLiteral(fieldValue.ToString());
+
+            Model model = new Model();
+
+            IValue value = obj.Build(model, ts, new Dictionary<string, IValue>());
+            value.Should().NotBeNull();
+            value.Should().BeOfType<Location>();
+
+            model.HeapInfo.TryGetNode((Location)value, out IHeapNode? node).Should().BeTrue();
+
+            IObjectHeapNode objNode = (IObjectHeapNode)node!;
+
+            objNode.MethodInvocations.Should().BeEmpty();
+
+            objNode.Fields.Should().BeEquivalentTo(new IField[] { fd });
+            objNode.TryGetField(fd, out IValue? fldValue).Should().BeTrue();
+            PrimitiveValue<int> intFldValue = (PrimitiveValue<int>)fldValue!;
+            intFldValue.Value.Should().Be(fieldValue);
+        }
+
+
+        [Theory]
+        [InlineData(new string?[] { null }, new int[] {0})]
+        [InlineData(new string?[] { "hello world", "string" }, new int[] { 0, 1 })]
+        [InlineData(new string?[] { "hello world", "string" }, new int[] { 2, 5 })]
+        [InlineData(new string?[] { "hello world", "\"\"", "6", null, "null" }, new int[] { 2, 5, 6, 7, 8 })]
+        public void BuildObjectWithPropertis(string?[] values, int[] invocations)
+        {
+            TypeSig ts = TestTypeSig;
+            TypeDef td = TestTypeDef;
+
+            PropertyDef pd = td.FindProperty(nameof(TestClass.Property));
+            MethodDef pGetter = pd.GetMethod;
+
+            UserObject obj = new UserObject() { Type = ts };
+            
+            for (int i = 0; i < invocations.Length; i++)
+            {
+                obj.MethodResults[(pGetter, invocations[i])] = new UserLiteral(values[i]);
+            }
+
+            Model model = new Model();
+
+            IValue value = obj.Build(model, ts, new Dictionary<string, IValue>());
+            value.Should().NotBeNull();
+            value.Should().BeOfType<Location>();
+
+            model.HeapInfo.TryGetNode((Location)value, out IHeapNode? node).Should().BeTrue();
+
+            IObjectHeapNode objNode = (IObjectHeapNode)node!;
+
+            objNode.Fields.Should().BeEmpty();
+            objNode.MethodInvocations.Should().HaveCount(invocations.Length);
+
+            int maxInvocation = invocations.Length == 0 ? 0 : invocations.Max();
+
+            for (int i = 0; i < maxInvocation; i++)
+            {
+                int idx = Array.IndexOf(invocations, i);
+
+                objNode.TryGetMethodResult(pGetter, i, out IValue? mr).Should().Be(idx >= 0);
+
+                if (idx >= 0)
+                {
+                    ((StringValue)mr!).Content.Should().Be(values[idx]?.Trim('"'));
+                }
+            }
+        }
+
+
+
+        [Theory]
+        [InlineData(new bool[] { true }, new int[] { 0 })]
+        [InlineData(new bool[] { true, false }, new int[] { 0, 1 })]
+        [InlineData(new bool[] { false, true }, new int[] { 2, 5 })]
+        public void BuildObjectWithMethods(bool[] values, int[] invocations)
+        {
+            TypeSig ts = TestTypeSig;
+            TypeDef td = TestTypeDef;
+
+            MethodDef md = td.FindMethod(nameof(TestClass.Method));
+
+            UserObject obj = new UserObject() { Type = ts };
+
+            for (int i = 0; i < invocations.Length; i++)
+            {
+                obj.MethodResults[(md, invocations[i])] = new UserLiteral(values[i].ToString());
+            }
+
+            Model model = new Model();
+
+            IValue value = obj.Build(model, ts, new Dictionary<string, IValue>());
+            value.Should().NotBeNull();
+            value.Should().BeOfType<Location>();
+
+            model.HeapInfo.TryGetNode((Location)value, out IHeapNode? node).Should().BeTrue();
+
+            IObjectHeapNode objNode = (IObjectHeapNode)node!;
+
+            objNode.Fields.Should().BeEmpty();
+            objNode.MethodInvocations.Should().HaveCount(invocations.Length);
+
+            int maxInvocation = invocations.Length == 0 ? 0 : invocations.Max();
+
+            for (int i = 0; i < maxInvocation; i++)
+            {
+                int idx = Array.IndexOf(invocations, i);
+
+                objNode.TryGetMethodResult(md, i, out IValue? mr).Should().Be(idx >= 0);
+
+                if (idx >= 0)
+                {
+                    ((PrimitiveValue<bool>)mr!).Value.Should().Be(values[idx]);
+                }
+            }
+        }
+    }
+}

--- a/dnWalker.Tests/Input/UserReferenceTests.cs
+++ b/dnWalker.Tests/Input/UserReferenceTests.cs
@@ -1,0 +1,53 @@
+﻿using dnWalker.Input;
+using dnWalker.Symbolic;
+
+using FluentAssertions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit.Abstractions;
+
+namespace dnWalker.Tests.Input
+{
+    public class UserReferenceTests : DnlibTestBase
+    {
+        public UserReferenceTests(ITestOutputHelper textOutput) : base(textOutput)
+        {
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("\t")]
+        [InlineData("\r\n")]
+        [InlineData("\r\n  \t  ")]
+        public void BuildNotInitializedReference(string invalidReference)
+        {
+            Action act = () => new UserReference() { Reference = invalidReference }.Build(new Model(), null, new Dictionary<string, IValue>());
+            act.Should().Throw<Exception>();
+        }
+
+        [Theory]
+        [InlineData("myObject")]
+        public void BuildExistingValue(string referenceName)
+        {
+            IValue referencedValue = new StringValue("Hello world");
+            IValue resolvedValue = new UserReference() { Reference = referenceName }.Build(new Model(), null, new Dictionary<string, IValue>() { [referenceName] = referencedValue });
+
+            resolvedValue.Should().Be(referencedValue);
+        }
+
+        [Theory]
+        [InlineData("myObject")]
+        public void BuildNonExistingValue(string referenceName)
+        {
+            Action act = () => new UserReference() { Reference = referenceName }.Build(new Model(), null, new Dictionary<string, IValue>());
+            act.Should().Throw<Exception>();
+        }
+    }
+}

--- a/dnWalker.Tests/Input/Xml/XmlUserModelParserTests.cs
+++ b/dnWalker.Tests/Input/Xml/XmlUserModelParserTests.cs
@@ -1,0 +1,296 @@
+﻿using dnlib.DotNet;
+
+using dnWalker.Input;
+using dnWalker.Input.Xml;
+
+using FluentAssertions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+
+using Xunit.Abstractions;
+
+namespace dnWalker.Tests.Input.Xml
+{
+    public class XmlUserModelParserTests : DnlibTestBase
+    {
+        public class TestClass
+        {
+            public TestClass? Other;
+
+            public int IntField;
+            public string? StringProperty { get; }
+            public bool BoolMethod() { return false; }
+
+            public static string StringStaticField = "hello world";
+            public static TestClass? ReferenceStaticField = null;
+
+            public void TestMethod(int intArg, int[] arrayArg, string strArg)
+            {
+
+            }
+        }
+
+        private readonly XmlUserModelParser Parser;
+
+
+        private readonly TypeDef TestTypeDef;
+        private readonly TypeSig TestTypeSig;
+        private readonly MethodDef TestMethod;
+
+        public XmlUserModelParserTests(ITestOutputHelper textOutput) : base(textOutput)
+        {
+            Parser = new XmlUserModelParser(DefinitionProvider);
+            TestTypeDef = DefinitionProvider.GetTypeDefinition("dnWalker.Tests.Input.Xml.XmlUserModelParserTests/TestClass");
+            TestTypeSig = TestTypeDef.ToTypeSig();
+            TestMethod = TestTypeDef.FindMethod(nameof(TestClass.TestMethod));
+        }
+
+        [Fact]
+        public void ParseNoModel()
+        {
+
+            const string XmlText =
+@"<UserModels>
+</UserModels>";
+            XElement xml = XElement.Parse(XmlText);
+
+            IList<UserModel> models = Parser.ParseModelCollection(xml);
+
+            models.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ParseEmptyModel()
+        {
+
+            const string XmlText =
+@"<UserModels>
+	<SharedData/>
+	<UserModel EntryPoint=""dnWalker.Tests.Input.Xml.XmlUserModelParserTests/TestClass.TestMethod"" />
+</UserModels>";
+            XElement xml = XElement.Parse(XmlText);
+
+            IList<UserModel> models = Parser.ParseModelCollection(xml);
+
+            models.Should().HaveCount(1);
+            models[0].Method.Should().BeEquivalentTo(TestMethod);
+        }
+
+        [Fact]
+        public void ParseSharedData()
+        {
+            const string XmlText =
+@"<UserModels>
+	<SharedData>
+        <Literal Id=""MyString"" Type=""System.String"">Hello world!</Literal>
+    </SharedData>
+	<UserModel EntryPoint=""dnWalker.Tests.Input.Xml.XmlUserModelParserTests/TestClass.TestMethod"" />
+</UserModels>";
+
+            XElement xml = XElement.Parse(XmlText);
+
+            IList<UserModel> models = Parser.ParseModelCollection(xml);
+
+            models[0].Data.Should().ContainKey("MyString");
+            ((UserLiteral)models[0].Data["MyString"]).Value.Should().Be("Hello world!");
+        }
+
+        [Fact]
+        public void ParseUserObject()
+        {
+            const string XmlText =
+@"<UserModels>
+	<SharedData>
+        <Object Id=""MyObject"" Type=""dnWalker.Tests.Input.Xml.XmlUserModelParserTests/TestClass"">
+            <IntField>5</IntField>
+            <StringProperty>Hello world!</StringProperty>
+            <BoolMethod>true</BoolMethod>
+            <BoolMethod>false</BoolMethod>
+            <StringProperty Invocation=""3"">Hello world!</StringProperty>
+            <BoolMethod Invocation=""5"">false</BoolMethod>
+        </Object>
+    </SharedData>
+	<UserModel EntryPoint=""dnWalker.Tests.Input.Xml.XmlUserModelParserTests/TestClass.TestMethod"" />
+</UserModels>";
+
+            XElement xml = XElement.Parse(XmlText);
+
+            IList<UserModel> models = Parser.ParseModelCollection(xml);
+
+            models[0].Data.TryGetValue("MyObject", out UserData? uValue).Should().BeTrue();
+            UserObject obj = (UserObject)uValue!;
+
+
+            // int field
+            FieldDef intField = TestTypeDef.FindField(nameof(TestClass.IntField));
+            obj.Fields[intField].Should().BeEquivalentTo(new UserLiteral() { Value = "5" });
+            
+            // bool method
+            MethodDef boolMethod = TestTypeDef.FindMethod(nameof(TestClass.BoolMethod));
+            obj.MethodResults[(boolMethod, 0)].Should().BeEquivalentTo(new UserLiteral() { Value = "true" });
+            obj.MethodResults[(boolMethod, 1)].Should().BeEquivalentTo(new UserLiteral() { Value = "false" });
+            obj.MethodResults.Should().NotContainKey((boolMethod, 2));
+            obj.MethodResults.Should().NotContainKey((boolMethod, 3));
+            obj.MethodResults.Should().NotContainKey((boolMethod, 4));
+            obj.MethodResults[(boolMethod, 5)].Should().BeEquivalentTo(new UserLiteral() { Value = "false" });
+            obj.MethodResults.Should().NotContainKey((boolMethod, 6));
+
+            // string property
+            MethodDef stringPropery = TestTypeDef.FindProperty(nameof(TestClass.StringProperty)).GetMethod;
+            obj.MethodResults[(stringPropery, 0)].Should().BeEquivalentTo(new UserLiteral() { Value = "Hello world!" });
+            obj.MethodResults.Should().NotContainKey((stringPropery, 1));
+            obj.MethodResults.Should().NotContainKey((stringPropery, 2));
+            obj.MethodResults[(stringPropery, 3)].Should().BeEquivalentTo(new UserLiteral() { Value = "Hello world!" });
+            obj.MethodResults.Should().NotContainKey((stringPropery, 4));
+        }
+
+        [Fact]
+        public void ParseUserArray()
+        {
+            const string XmlText =
+@"<UserModels>
+	<SharedData>
+        <Array Id=""MyArray"" ElementType=""System.String"" Length=""10"">
+            <Literal Index=""2"">null</Literal>
+            <Literal>foo</Literal>
+            <Literal Index=""7"">bar</Literal>
+        </Array>
+    </SharedData>
+	<UserModel EntryPoint=""dnWalker.Tests.Input.Xml.XmlUserModelParserTests/TestClass.TestMethod"" />
+</UserModels>";
+
+
+            XElement xml = XElement.Parse(XmlText);
+
+            IList<UserModel> models = Parser.ParseModelCollection(xml);
+
+            models[0].Data.TryGetValue("MyArray", out UserData? uValue).Should().BeTrue();
+            UserArray arr = (UserArray)uValue!;
+
+            arr.Length.Should().Be(10);
+            arr.Elements.Should().NotContainKey(0);
+            arr.Elements.Should().NotContainKey(1);
+            arr.Elements[2].Should().BeEquivalentTo(new UserLiteral("null"));
+            arr.Elements[3].Should().BeEquivalentTo(new UserLiteral("foo"));
+            arr.Elements.Should().NotContainKey(4);
+            arr.Elements.Should().NotContainKey(5);
+            arr.Elements.Should().NotContainKey(6);
+            arr.Elements[7].Should().BeEquivalentTo(new UserLiteral("bar"));
+            arr.Elements.Should().NotContainKey(8);
+            arr.Elements.Should().NotContainKey(9);
+        }
+
+        [Fact]
+        public void ParseMethodArguments()
+        {
+            const string XmlText =
+@"<UserModels>
+	<SharedData>
+        <Object Id=""MyObject"" Type=""dnWalker.Tests.Input.Xml.XmlUserModelParserTests/TestClass"">
+            <IntField>5</IntField>
+            <StringProperty>Hello world!</StringProperty>
+            <BoolMethod>true</BoolMethod>
+            <BoolMethod>false</BoolMethod>
+            <StringProperty Invocation=""3"">Hello world!</StringProperty>
+            <BoolMethod Invocation=""5"">false</BoolMethod>
+        </Object>
+    </SharedData>
+	<UserModel EntryPoint=""dnWalker.Tests.Input.Xml.XmlUserModelParserTests/TestClass.TestMethod"">
+        <m-this>
+            <Reference>MyObject</Reference>
+        </m-this>
+        <strArg>Hello world!</strArg>
+    </UserModel>
+</UserModels>";
+
+            XElement xml = XElement.Parse(XmlText);
+
+            UserModel model = Parser.ParseModelCollection(xml)[0];
+
+            model.MethodArguments[TestMethod.Parameters[0]].Should().BeEquivalentTo(new UserReference("MyObject"));
+            model.MethodArguments[TestMethod.Parameters[3]].Should().BeEquivalentTo(new UserLiteral("Hello world!"));
+        }
+
+        [Fact]
+        public void ParseStaticFields()
+        {
+            const string XmlText =
+@"<UserModels>
+	<SharedData>
+        <Object Id=""MyObject"" Type=""dnWalker.Tests.Input.Xml.XmlUserModelParserTests/TestClass"">
+            <IntField>5</IntField>
+            <StringProperty>Hello world!</StringProperty>
+            <BoolMethod>true</BoolMethod>
+            <BoolMethod>false</BoolMethod>
+            <StringProperty Invocation=""3"">Hello world!</StringProperty>
+            <BoolMethod Invocation=""5"">false</BoolMethod>
+        </Object>
+    </SharedData>
+	<UserModel EntryPoint=""dnWalker.Tests.Input.Xml.XmlUserModelParserTests/TestClass.TestMethod"">
+        <dnWalker.Tests.Input.Xml.XmlUserModelParserTests-TestClass.StringStaticField>Hello world!</dnWalker.Tests.Input.Xml.XmlUserModelParserTests-TestClass.StringStaticField>
+        <dnWalker.Tests.Input.Xml.XmlUserModelParserTests-TestClass.ReferenceStaticField>
+            <Reference>MyObject</Reference>
+        </dnWalker.Tests.Input.Xml.XmlUserModelParserTests-TestClass.ReferenceStaticField>
+    </UserModel>
+</UserModels>";
+
+            XElement xml = XElement.Parse(XmlText);
+
+            UserModel model = Parser.ParseModelCollection(xml)[0];
+
+            FieldDef stringStaticField = TestTypeDef.FindField(nameof(TestClass.StringStaticField));
+            FieldDef referenceStaticField = TestTypeDef.FindField(nameof(TestClass.ReferenceStaticField));
+
+            model.StaticFields[stringStaticField].Should().BeEquivalentTo(new UserLiteral("Hello world!"));
+            model.StaticFields[referenceStaticField].Should().BeEquivalentTo(new UserReference("MyObject"));
+        }
+
+        [Fact]
+        public void ParseMethodArgumentsAndStaticFields()
+        {
+            const string XmlText =
+@"<UserModels>
+	<SharedData>
+        <Object Id=""MyObject"" Type=""dnWalker.Tests.Input.Xml.XmlUserModelParserTests/TestClass"">
+            <IntField>5</IntField>
+            <StringProperty>Hello world!</StringProperty>
+            <BoolMethod>true</BoolMethod>
+            <BoolMethod>false</BoolMethod>
+            <StringProperty Invocation=""3"">Hello world!</StringProperty>
+            <BoolMethod Invocation=""5"">false</BoolMethod>
+        </Object>
+    </SharedData>
+	<UserModel EntryPoint=""dnWalker.Tests.Input.Xml.XmlUserModelParserTests/TestClass.TestMethod"">
+        <m-this>
+            <Reference>MyObject</Reference>
+        </m-this>
+        <strArg>Hello world!</strArg>
+        <dnWalker.Tests.Input.Xml.XmlUserModelParserTests-TestClass.StringStaticField>Hello world!</dnWalker.Tests.Input.Xml.XmlUserModelParserTests-TestClass.StringStaticField>
+        <dnWalker.Tests.Input.Xml.XmlUserModelParserTests-TestClass.ReferenceStaticField>
+            <Reference>MyObject</Reference>
+        </dnWalker.Tests.Input.Xml.XmlUserModelParserTests-TestClass.ReferenceStaticField>
+    </UserModel>
+</UserModels>";
+
+            XElement xml = XElement.Parse(XmlText);
+
+            UserModel model = Parser.ParseModelCollection(xml)[0];
+
+            model.MethodArguments[TestMethod.Parameters[0]].Should().BeEquivalentTo(new UserReference("MyObject"));
+            model.MethodArguments[TestMethod.Parameters[3]].Should().BeEquivalentTo(new UserLiteral("Hello world!"));
+
+            FieldDef stringStaticField = TestTypeDef.FindField(nameof(TestClass.StringStaticField));
+            FieldDef referenceStaticField = TestTypeDef.FindField(nameof(TestClass.ReferenceStaticField));
+
+            model.StaticFields[stringStaticField].Should().BeEquivalentTo(new UserLiteral("Hello world!"));
+            model.StaticFields[referenceStaticField].Should().BeEquivalentTo(new UserReference("MyObject"));
+        }
+    }
+}
+

--- a/dnWalker/Input/UserArray.cs
+++ b/dnWalker/Input/UserArray.cs
@@ -1,0 +1,52 @@
+﻿using dnlib.DotNet;
+
+using dnWalker.Symbolic;
+using dnWalker.Symbolic.Heap;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace dnWalker.Input
+{
+    public class UserArray : UserData
+    {
+        public int Length
+        {
+            get;
+            set;
+        }
+
+        public IDictionary<int, UserData> Elements
+        {
+            get;
+        } = new Dictionary<int, UserData>();
+
+        public TypeSig ElementType
+        {
+            get;
+            set;
+        }
+
+        public override IValue Build(IModel model, TypeSig expectedType, IDictionary<string, IValue> references)
+        {
+            TypeSig elementType = ElementType ?? expectedType.Next ?? throw new InvalidOperationException();
+
+            // assert elementType is assignable to expectedType.Next!!!
+
+            int length = Elements.Keys.Count > 0 ? Elements.Keys.Max() + 1 : 0;
+
+            IArrayHeapNode arrayNode = model.HeapInfo.InitializeArray(elementType, length);
+            SetReference(arrayNode.Location, references);
+
+            foreach ((int index, UserData ud) in Elements)
+            {
+                arrayNode.SetElement(index, ud.Build(model, elementType, references));
+            }
+
+            return arrayNode.Location;
+        }
+    }
+}

--- a/dnWalker/Input/UserData.cs
+++ b/dnWalker/Input/UserData.cs
@@ -1,0 +1,32 @@
+﻿using dnlib.DotNet;
+
+using dnWalker.Symbolic;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace dnWalker.Input
+{
+    public abstract class UserData
+    {
+        public string Id
+        {
+            get;
+            set;
+        }
+
+        public abstract IValue Build(IModel model, TypeSig expectedType, IDictionary<string, IValue> references);
+
+        protected void SetReference(IValue value, IDictionary<string, IValue> references)
+        {
+            string id = Id;
+            if (!string.IsNullOrWhiteSpace(id))
+            {
+                references[id] = value;
+            }
+        }
+    }
+}

--- a/dnWalker/Input/UserLiteral.cs
+++ b/dnWalker/Input/UserLiteral.cs
@@ -1,0 +1,60 @@
+﻿using dnlib.DotNet;
+
+using dnWalker.Symbolic;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace dnWalker.Input
+{
+    public class UserLiteral : UserData
+    {
+        private string _value;
+
+        public UserLiteral()
+        {
+
+        }
+
+        public UserLiteral(string value)
+        {
+            _value = value;
+        }
+
+        public string Value
+        {
+            get
+            {
+                return _value;
+            }
+
+            set
+            {
+                _value = value;
+            }
+        }
+
+        public TypeSig Type
+        {
+            get;
+            set;
+        }
+
+        public override IValue Build(IModel model, TypeSig expectedType, IDictionary<string, IValue> references)
+        {
+            TypeSig type = Type ?? expectedType ?? throw new Exception("The type is not provided!");
+
+            string strValue = _value;
+
+            IValue value = ValueFactory.ParseValue(strValue, type);
+
+            if (value == null) throw new Exception($"Could not parse literal '{strValue}' as '{type}'");
+
+            SetReference(value, references);
+            return value;
+        }
+    }
+}

--- a/dnWalker/Input/UserModel.cs
+++ b/dnWalker/Input/UserModel.cs
@@ -1,0 +1,61 @@
+﻿using dnlib.DotNet;
+
+using dnWalker.Symbolic;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace dnWalker.Input
+{
+    public class UserModel
+    {
+        public UserModel()
+        {
+            Data = new Dictionary<string, UserData>();
+        }
+
+        public UserModel(IReadOnlyDictionary<string, UserData> sharedData)
+        {
+            Data = new Dictionary<string, UserData>(sharedData);
+        }
+
+        public IDictionary<string, UserData> Data { get; }
+
+        public MethodDef Method { get; set; }
+
+        public IDictionary<Parameter, UserData> MethodArguments { get; } = new Dictionary<Parameter, UserData>();
+        public IDictionary<FieldDef, UserData> StaticFields { get; } = new Dictionary<FieldDef, UserData>();
+
+        public IModel Build()
+        {
+            Model model = new Model();
+            Dictionary<string, IValue> references = new Dictionary<string, IValue>();
+
+            // build the shared data
+            foreach ((string id, UserData userData) in Data)
+            {
+                IValue value = userData.Build(model, null, references);
+                references[id] = value;
+            }
+
+            // build static fields
+            foreach ((FieldDef fd, UserData userData) in StaticFields)
+            {
+                IValue fieldValue = userData.Build(model, fd.FieldType, references);
+                model.SetValue((IRootVariable)Variable.StaticField(fd), fieldValue);
+            }
+
+            // build method arguments
+            foreach ((Parameter p, UserData userData) in MethodArguments)
+            {
+                IValue argValue = userData.Build(model, p.Type, references);
+                model.SetValue((IRootVariable)Variable.MethodArgument(p), argValue);
+            }
+
+            return model;
+        }
+    }
+}

--- a/dnWalker/Input/UserObject.cs
+++ b/dnWalker/Input/UserObject.cs
@@ -1,0 +1,54 @@
+﻿using dnlib.DotNet;
+
+using dnWalker.Symbolic;
+using dnWalker.Symbolic.Heap;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace dnWalker.Input
+{
+    public class UserObject : UserData
+    {
+        public TypeSig Type
+        {
+            get;
+            set;
+        }
+
+        public IDictionary<FieldDef, UserData> Fields
+        {
+            get;
+        } = new Dictionary<FieldDef, UserData>();
+
+        public IDictionary<(MethodDef, int), UserData> MethodResults
+        {
+            get;
+        } = new Dictionary<(MethodDef, int), UserData>();
+
+        public override IValue Build(IModel model, TypeSig expectedType, IDictionary<string, IValue> references)
+        {
+            TypeSig type = Type ?? expectedType ?? throw new InvalidOperationException();
+
+            // assert type is assignable to expectedType !!!!
+
+            IObjectHeapNode objectNode = model.HeapInfo.InitializeObject(type);
+            SetReference(objectNode.Location, references);
+
+            foreach ((FieldDef fd, UserData ud) in Fields)
+            {
+                objectNode.SetField(fd, ud.Build(model, fd.FieldType, references));
+            }
+
+            foreach (((MethodDef md, int invocation), UserData ud) in MethodResults)
+            {
+                objectNode.SetMethodResult(md, invocation, ud.Build(model, md.ReturnType, references));
+            }
+
+            return objectNode.Location;
+        }
+    }
+}

--- a/dnWalker/Input/UserReference.cs
+++ b/dnWalker/Input/UserReference.cs
@@ -1,0 +1,46 @@
+﻿using dnlib.DotNet;
+
+using dnWalker.Symbolic;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace dnWalker.Input
+{
+    public class UserReference : UserData
+    {
+        public UserReference()
+        {
+        }
+
+        public UserReference(string reference)
+        {
+            Reference = reference;
+        }
+
+        public override IValue Build(IModel model, TypeSig expectedType, IDictionary<string, IValue> references)
+        {
+            if (string.IsNullOrWhiteSpace(Reference))
+            {
+                throw new InvalidOperationException("The reference is not set.");
+            }
+
+
+            if (references.TryGetValue(Reference, out IValue value))
+            {
+                return value;
+            }
+
+            throw new Exception("Reference not found.");
+        }
+
+        public string Reference
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/dnWalker/Input/Xml/XmlTokens.cs
+++ b/dnWalker/Input/Xml/XmlTokens.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+using System.Xml.Linq;
+
+namespace dnWalker.Input.Xml
+{
+    internal static class XmlTokens
+    {
+        public const string SharedData = nameof(SharedData);
+        public const string UserModels = nameof(UserModels);
+        public const string UserModel = nameof(UserModel);
+
+        public const string Reference = nameof(Reference);
+        public const string Object = nameof(Object);
+        public const string Array = nameof(Array);
+        public const string Literal = nameof(Literal);
+
+        public const string Id = nameof(Id);
+        public const string Type = nameof(Type);
+
+        public const string Length = nameof(Length);
+        public const string Element = nameof(Element);
+        public const string ElementType = nameof(ElementType);
+        public const string Index = nameof(Index);
+
+        public const string Member = nameof(Member);
+        public const string Name = nameof(Name);
+        public const string Invocation = nameof(Invocation);
+
+        public const string Argument = nameof(Argument);
+        public const string StaticMember = nameof(StaticMember);
+
+        public const string EntryPoint = nameof(EntryPoint);
+    }
+}

--- a/dnWalker/Input/Xml/XmlUserModelParser.cs
+++ b/dnWalker/Input/Xml/XmlUserModelParser.cs
@@ -1,0 +1,346 @@
+﻿using dnlib.DotNet;
+
+using dnWalker.TypeSystem;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace dnWalker.Input.Xml
+{
+    public class XmlUserModelParser
+    {
+        private readonly IDefinitionProvider _definitionProvider;
+
+        public XmlUserModelParser(IDefinitionProvider definitionProvider)
+        {
+            _definitionProvider = definitionProvider;
+        }
+
+        public IList<UserModel> ParseModelCollection(XElement xml)
+        {
+            Dictionary<string, UserData> sharedData = new Dictionary<string, UserData>();
+
+            XElement sharedDataXml = xml.Element(XmlTokens.SharedData);
+            if (sharedDataXml != null)
+            {
+                foreach (XElement sharedXml in sharedDataXml.Elements())
+                {
+                    UserData userData = ParseUserData(sharedXml, sharedData);
+
+                    Debug.Assert(userData != null && !String.IsNullOrWhiteSpace(userData.Id));
+
+                    //sharedData.Add(userData.Id, userData);
+                }
+            }
+
+            List<UserModel> userModels = new List<UserModel>();
+            foreach (XElement modelXml in xml.Elements(XmlTokens.UserModel))
+            {
+                UserModel model = ParseModel(modelXml, sharedData);
+
+                Debug.Assert(model != null);
+
+                userModels.Add(model);
+            }
+
+            return userModels;
+        }
+
+        public UserModel ParseModel(XElement xml, IReadOnlyDictionary<string, UserData> sharedData = null)
+        {
+            UserModel userModel = sharedData == null ? new UserModel() : new UserModel(sharedData);
+
+            IDictionary<string, UserData> references = userModel.Data;
+
+            string methodName = xml.Attribute(XmlTokens.EntryPoint)?.Value ?? throw new Exception("UserModel XML must have attribute EntryPoint");
+            
+            MethodDef method = _definitionProvider.GetMethodDefinition(methodName);
+            userModel.Method = method;
+
+
+            //foreach (XElement argXml in xml.Elements(XmlTokens.Argument))
+            //{
+            //    string name = argXml.Attribute(XmlTokens.Name)?.Value ?? throw new Exception("Argument XMl must have attribute name.");
+            //    Parameter parameter = method.Parameters.First(p => p.Name == name);
+
+            //    userModel.MethodArguments[parameter] = ParseUserData(argXml.Elements().First(), userModel.Data);
+            //}
+
+            // TODO handle all kinds of static data...
+
+            foreach (IGrouping<string, XElement> varGroup in xml.Elements().GroupBy(varXml => varXml.Name.LocalName))
+            {
+                string varName = varGroup.Key;
+                int nextInvocation = 0;
+                foreach (XElement varXml in varGroup)
+                {
+                    if (!TrySetupAsMethodArgument(varName, varXml) &&
+                        !TrySetupAsStaticField(varName, varXml))
+                    // !TrySetupAsStaticMethod(varName, varXml) &&
+                    // !TrySetupAsStaticProperty(varName, varXml))
+                    {
+                        throw new Exception($"Could not match any variable for '{varName}'");
+                    }
+                }
+            }
+
+            return userModel;
+
+            bool TrySetupAsMethodArgument(string varName, XElement varXml)
+            {
+                if (varName == "m-this")
+                {
+                    if (!method.HasThis)
+                    {
+                        throw new Exception("Trying to set 'this' parameter for method without hidden 'this' parameter.");
+                    }
+
+                    Parameter thisParameter = method.Parameters[0];
+
+                    userModel.MethodArguments[thisParameter] = ParseUserDataFromValue(varXml, references);
+
+                    return true;
+                }
+                else
+                {
+                    Parameter parameter = method.Parameters.FirstOrDefault(p => p.Name == varName);
+                    if (parameter != null)
+                    {
+                        userModel.MethodArguments[parameter] = ParseUserDataFromValue(varXml, references);
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            bool TrySetupAsStaticField(string varName, XElement varXml)
+            {
+                string fullFieldName = varName.Replace('-', '/');
+
+                int lastDot = fullFieldName.LastIndexOf(".");
+                string fieldTypeName = fullFieldName.Substring(0, lastDot);
+
+                TypeDef theType = _definitionProvider.GetTypeDefinition(fieldTypeName);
+                if (theType != null)
+                {
+                    string fieldName = fullFieldName.Substring(lastDot + 1);
+                    FieldDef fd = theType.FindField(fieldName);
+                    if (fd != null)
+                    {
+                        userModel.StaticFields[fd] = ParseUserDataFromValue(varXml, references);
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+
+        private UserData ParseUserData(XElement xml, IDictionary<string, UserData> references)
+        {
+            UserData userData = xml.Name.LocalName switch
+            {
+                XmlTokens.Reference => ParseReference(xml, references),
+                XmlTokens.Object => ParseObject(xml, references),
+                XmlTokens.Array => ParseArray(xml, references),
+                XmlTokens.Literal => ParseLiteral(xml, references),
+                _ => null
+            };
+
+            if (userData != null)
+            {
+                string id = xml.Attribute(XmlTokens.Id)?.Value;
+                if (!string.IsNullOrWhiteSpace(id))
+                {
+                    userData.Id = id;
+                    references[id] = userData;
+                }
+
+                return userData;
+            }
+            throw new NotSupportedException($"Unsupported xml: {xml}");
+        }
+
+        private UserData ParseUserDataFromValue(XElement xml, IDictionary<string, UserData> references)
+        {
+            if (xml.HasElements)
+            {
+                return ParseUserData(xml.Elements().First(), references);
+            }
+            else
+            {
+                return new UserLiteral() { Value = xml.Value.Trim() };
+            }
+        }
+
+        private UserReference ParseReference(XElement xml, IDictionary<string, UserData> references)
+        {
+            return new UserReference() { Reference = xml.Value.Trim() };
+        }
+
+        private UserObject ParseObject(XElement xml, IDictionary<string, UserData> references)
+        {
+            TypeSig type = GetType(xml, _definitionProvider);
+            Debug.Assert(type != null, "Object must have defined type.");
+
+            UserObject uObject = new UserObject()
+            {
+                Type = type
+            };
+
+            TypeDef td = type.ToTypeDefOrRef().ResolveTypeDefThrow();
+
+            //foreach(IGrouping<string, XElement> memberGroup in xml.Elements(XmlTokens.Member).GroupBy(mXml => (string)mXml.Attribute(XmlTokens.Name)))
+            foreach(IGrouping<string, XElement> memberGroup in xml.Elements().GroupBy(mXml => mXml.Name.LocalName))
+            {
+                string memberName = memberGroup.Key;
+                int nextInvocation = 0;
+
+                foreach (XElement memberXml in memberGroup)
+                {
+                    if (!TrySetupAsField(memberName, memberXml) &&
+                        !TrySetupAsMethod(memberName, memberXml) &&
+                        !TrySetupAsProperty(memberName, memberXml))
+                    {
+                        throw new Exception($"Member '{memberName}' could not have been matched up to any field, method or property of '{type}'.");
+                    }
+                }
+
+
+
+                bool TrySetupAsField(string memberName, XElement memberXml)
+                {
+                    FieldDef fd = td.FindField(memberName);
+                    if (fd != null)
+                    {
+                        uObject.Fields[fd] = ParseUserDataFromValue(memberXml, references);
+                        return true;
+                    }
+                    return false;
+                }
+
+                bool TrySetupAsProperty(string memberName, XElement memberXml)
+                {
+                    PropertyDef pd = td.FindProperty(memberName);
+                    if (pd != null)
+                    {
+                        // ignore inner working && ignore setter
+                        int invocation = GetAndUpdateCounter(ref nextInvocation, GetInvocation(memberXml));
+                        UserData memberValue = ParseUserDataFromValue(memberXml, references);
+                        uObject.MethodResults[(pd.GetMethod, invocation)] = memberValue;
+                        return true;
+                    }
+                    return false;
+                }
+
+                bool TrySetupAsMethod(string memberName, XElement memberXml)
+                {
+                    MethodDef md = td.FindMethod(memberName);
+                    if (md != null)
+                    {
+                        int invocation = GetAndUpdateCounter(ref nextInvocation, GetInvocation(memberXml));
+                        UserData memberValue = ParseUserDataFromValue(memberXml, references);
+                        uObject.MethodResults[(md, invocation)] = memberValue;
+                        return true;
+                    }
+                    return false;
+                }
+            }
+
+
+            return uObject;
+        }
+
+
+        private UserArray ParseArray(XElement xml, IDictionary<string, UserData> references)
+        {
+            UserArray array = new UserArray()
+            {
+                ElementType = GetElementType(xml, _definitionProvider),
+            };
+
+            int nextIndex = 0;
+            foreach (XElement elementXml in xml.Elements())
+            {
+                int index = GetAndUpdateCounter(ref nextIndex, GetIndex(elementXml));
+
+                UserData elementData = ParseUserData(elementXml, references);
+                array.Elements[index] = elementData;
+            }
+
+            int length = GetLength(xml);
+            if (length == -1)
+            {
+                length = nextIndex;
+            }
+
+            array.Length = length;
+            return array;
+        }
+
+        private UserLiteral ParseLiteral(XElement xml, IDictionary<string, UserData> references)
+        {
+            TypeSig type = GetType(xml, _definitionProvider);
+            return new UserLiteral() { Value = xml.Value.Trim(), Type = type };
+        }
+
+        private static int GetLength(XElement xml)
+        {
+            string str = xml.Attribute(XmlTokens.Length)?.Value;
+            if (str != null) return int.Parse(str);
+            return -1;
+        }
+        private static int GetIndex(XElement xml)
+        {
+            string str = xml.Attribute(XmlTokens.Index)?.Value;
+            if (str != null) return int.Parse(str);
+            return -1;
+        }
+
+        private static int GetAndUpdateCounter(ref int currentCounter, int counterValue)
+        {
+            if (counterValue == -1)
+            {
+                counterValue = currentCounter++;
+            }
+            else
+            {
+                if (counterValue <= currentCounter)
+                {
+                    throw new Exception("Invalid XML, invocations must be rising sequence");
+                }
+                currentCounter = counterValue + 1;
+            }
+            return counterValue;
+        }
+
+        private static int GetInvocation(XElement xml)
+        {
+            string str = xml.Attribute(XmlTokens.Invocation)?.Value;
+            if (str != null) return int.Parse(str);
+            return -1;
+        }
+
+        private static TypeSig GetElementType(XElement xml, IDefinitionProvider definitionProvider)
+        {
+            string str = xml.Attribute(XmlTokens.ElementType)?.Value;
+            if (str != null) return definitionProvider.GetTypeDefinition(str).ToTypeSig();
+            return null;
+        }
+        private static TypeSig GetType(XElement xml, IDefinitionProvider definitionProvider)
+        {
+            string str = xml.Attribute(XmlTokens.Type)?.Value;
+            if (str != null) return definitionProvider.GetTypeDefinition(str).ToTypeSig();
+            return null;
+        }
+    }
+}

--- a/dnWalker/dnWalker.csproj
+++ b/dnWalker/dnWalker.csproj
@@ -22,4 +22,8 @@
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Input\" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Přidání vrstvy abstrakce při nastavení vstupu do testované metody - `UserModel`. `UserModel `představuje obecnou datovou strukturu, která by se mohla vyčíst z různých formátů - zatím je implementovaný XML, protože jeho atributy jsou přívětivé a hezky se s nimi pracuje. Mělo by ale být možné udělat i formát na základě JSON nebo YAML nebo čehokoliv jiného.

Z `UserModel` se pak může vybudovat instance dnWalker.Symbolic.IModel, ze kterého se vytvoří precondition pro běhy `ConcolicExplorer` ([https://github.com/kfrajtak/dnWalker/pull/39](https://github.com/kfrajtak/dnWalker/pull/39)).

Tento XML formát už by měl být user-friendly. V jednom souboru je možné definovat více modelů pro různé metody, které mohou sdílet data. Každý element modelu může mít své ID, přes které je možné jej referencovat. Je tam ale pár omezení - odkazovaná data musí být buď přímým předkem, nebo součástí sdílených dat (je to způsobené pouze naivní a jednoduchou implementací metody `UserModel.Build()`, nepochybně lze v budoucnosti předělat, aby bylo možné odkazovat na libovolné elementy).

V budoucnu bych to chtěl rozšířit i o deklaraci namespaců (třeba i přes `xmlns`) a aliasů, aby se mohlo zjednodušit vypisování typů. Je tam také komplikace s určením nějakých speciálních elementů - například argument `this`. Zatím jsem to obešel vytvořením speciálního klíčového slova `m-this`, protože `-` nemůže být součástí názvu proměnné, ale vzhledem k použití XML by bylo elegantnější využít `xmlns`.