### PR TITLE
Feature/concolic exploration md instead of strings

### DIFF
--- a/dnWalker.Explorations.Tests/dnWalker.Explorations.Tests.csproj
+++ b/dnWalker.Explorations.Tests/dnWalker.Explorations.Tests.csproj
@@ -25,8 +25,4 @@
     <ProjectReference Include="..\dnWalker.Explorations\dnWalker.Explorations.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Xml\" />
-  </ItemGroup>
-
 </Project>

--- a/dnWalker.Explorations/ConcolicExploration.Builder.cs
+++ b/dnWalker.Explorations/ConcolicExploration.Builder.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using dnlib.DotNet;
+
+using System;
 using System.Collections.Generic;
 
 namespace dnWalker.Explorations
@@ -9,7 +11,7 @@ namespace dnWalker.Explorations
         {
             public string? AssemblyName { get; set; }
             public string? AssemblyFileName { get; set; }
-            public string? MethodSignature { get; set; }
+            public IMethod? MethodUnderTest { get; set; }
             public string? Solver { get; set; }
             public DateTime Start { get; set; }
             public DateTime End { get; set; }
@@ -23,10 +25,10 @@ namespace dnWalker.Explorations
             {
                 if (AssemblyName == null) throw new NullReferenceException("AssemblyName is NULL");
                 if (AssemblyFileName == null) throw new NullReferenceException("AssemblyFileName is NULL");
-                if (MethodSignature == null) throw new NullReferenceException("MethodSignature is NULL");
+                if (MethodUnderTest == null) throw new NullReferenceException("MethodUnderTest is NULL");
                 if (Solver == null) throw new NullReferenceException("Solver is NULL");
 
-                ConcolicExploration exploration = new ConcolicExploration(AssemblyName, AssemblyFileName, MethodSignature, Solver, Start, End, Failed);
+                ConcolicExploration exploration = new ConcolicExploration(AssemblyName, AssemblyFileName, MethodUnderTest, Solver, Start, End, Failed);
 
                 foreach (var i in Iterations)
                 {

--- a/dnWalker.Explorations/ConcolicExploration.cs
+++ b/dnWalker.Explorations/ConcolicExploration.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using dnlib.DotNet;
+
+using System;
 using System.Collections.Generic;
 
 namespace dnWalker.Explorations
@@ -7,11 +9,11 @@ namespace dnWalker.Explorations
     {
         private readonly List<ConcolicExplorationIteration> _iterations = new List<ConcolicExplorationIteration>();
 
-        private ConcolicExploration(string assemblyName, string assemblyFileName, string methodSignature, string solver, DateTime start, DateTime end, bool failed)
+        private ConcolicExploration(string assemblyName, string assemblyFileName, IMethod methodUnderTest, string solver, DateTime start, DateTime end, bool failed)
         {
             AssemblyName = assemblyName ?? throw new ArgumentNullException(nameof(assemblyName));
             AssemblyFileName = assemblyFileName ?? throw new ArgumentNullException(nameof(assemblyFileName));
-            MethodSignature = methodSignature ?? throw new ArgumentNullException(nameof(methodSignature));
+            MethodUnderTest = methodUnderTest ?? throw new ArgumentNullException(nameof(methodUnderTest));
             Solver = solver ?? throw new ArgumentNullException(nameof(solver));
             Start = start;
             End = end;
@@ -28,7 +30,7 @@ namespace dnWalker.Explorations
 
         public string AssemblyName { get; }
         public string AssemblyFileName { get; }
-        public string MethodSignature { get; }
+        public IMethod MethodUnderTest { get; }
         public string Solver { get; }
         public DateTime Start { get; }
         public DateTime End { get; }

--- a/dnWalker.Explorations/ConcolicExplorationIteration.Builder.cs
+++ b/dnWalker.Explorations/ConcolicExplorationIteration.Builder.cs
@@ -1,4 +1,6 @@
-﻿using dnWalker.Symbolic;
+﻿using dnlib.DotNet;
+
+using dnWalker.Symbolic;
 
 using System;
 
@@ -16,7 +18,7 @@ namespace dnWalker.Explorations
             public DateTime Start { get; set; }
             public DateTime End { get; set; }
             public string? PathConstraint { get; set; }
-            public string? Exception { get; set; }
+            public TypeSig? Exception { get; set; }
             public string? StandardOutput { get; set; }
             public string? ErrorOutput { get; set; }
 
@@ -26,7 +28,6 @@ namespace dnWalker.Explorations
                 if (InputModel == null) throw new NullReferenceException("The BaseParameterSet is NULL");
                 if (OutputModel == null) throw new NullReferenceException("The ExecutionParameterSet is NULL");
                 if (PathConstraint == null) throw new NullReferenceException("The PathConstraint is NULL");
-                if (Exception == null) throw new NullReferenceException("The Exception is NULL");
                 if (StandardOutput == null) throw new NullReferenceException("The StandardOutput is NULL");
                 if (ErrorOutput == null) throw new NullReferenceException("The ErrorOutput is NULL");
 

--- a/dnWalker.Explorations/ConcolicExplorationIteration.cs
+++ b/dnWalker.Explorations/ConcolicExplorationIteration.cs
@@ -1,4 +1,6 @@
-﻿using dnWalker.Symbolic;
+﻿using dnlib.DotNet;
+
+using dnWalker.Symbolic;
 
 using System;
 
@@ -12,8 +14,8 @@ namespace dnWalker.Explorations
                                              IReadOnlyModel outputModel,
                                              DateTime start,
                                              DateTime end,
-                                             string pathConstraint, 
-                                             string exception, 
+                                             string pathConstraint,
+                                             TypeSig? exception, 
                                              string standardOutput, 
                                              string errorOutput)
         {
@@ -24,7 +26,7 @@ namespace dnWalker.Explorations
             Start = start;
             End = end;
             PathConstraint = pathConstraint ?? throw new ArgumentNullException(nameof(pathConstraint));
-            Exception = exception ?? throw new ArgumentNullException(nameof(exception));
+            Exception = exception;
             StandardOutput = standardOutput ?? throw new ArgumentNullException(nameof(standardOutput));
             ErrorOutput = errorOutput ?? throw new ArgumentNullException(nameof(errorOutput));
         }
@@ -36,7 +38,7 @@ namespace dnWalker.Explorations
         public DateTime Start { get; }
         public DateTime End { get; }
 
-        public string Exception { get; }
+        public TypeSig? Exception { get; }
         public string StandardOutput { get; }
         public string ErrorOutput { get; }
         public string PathConstraint { get; }

--- a/dnWalker.Explorations/Xml/XmlExplorationDeserializer.cs
+++ b/dnWalker.Explorations/Xml/XmlExplorationDeserializer.cs
@@ -16,11 +16,13 @@ namespace dnWalker.Explorations.Xml
 {
     public class XmlExplorationDeserializer
     {
+        private readonly ITypeParser _typeParser;
         private readonly IMethodParser _methodParser;
         private readonly XmlModelDeserializer _modelDeserializer;
 
-        public XmlExplorationDeserializer(IMethodParser methodParser, XmlModelDeserializer modelDeserializer)
+        public XmlExplorationDeserializer(ITypeParser typeParser, IMethodParser methodParser, XmlModelDeserializer modelDeserializer)
         {
+            _typeParser = typeParser;
             _methodParser = methodParser;
             _modelDeserializer = modelDeserializer;
         }
@@ -36,9 +38,11 @@ namespace dnWalker.Explorations.Xml
 
             builder.AssemblyName = xml.Attribute(XmlTokens.AssemblyName)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExploration), XmlTokens.AssemblyName);
             builder.AssemblyFileName = xml.Attribute(XmlTokens.AssemblyFileName)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExploration), XmlTokens.AssemblyFileName);
+            
             string methodSignature = xml.Attribute(XmlTokens.MethodSignature)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExploration), XmlTokens.MethodSignature);
             IMethod method = _methodParser.Parse(methodSignature);
             builder.MethodUnderTest = method;
+            
             builder.Solver = xml.Attribute(XmlTokens.Solver)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExploration), XmlTokens.Solver);
             builder.Start = DateTime.ParseExact(xml.Attribute(XmlTokens.Start)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExploration), XmlTokens.Start), XmlTokens.DateTimeFormat, CultureInfo.InvariantCulture);
             builder.End = DateTime.ParseExact(xml.Attribute(XmlTokens.End)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExploration), XmlTokens.Start), XmlTokens.DateTimeFormat, CultureInfo.InvariantCulture);
@@ -61,7 +65,13 @@ namespace dnWalker.Explorations.Xml
             builder.End = DateTime.ParseExact(xml.Attribute(XmlTokens.End)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExplorationIteration), XmlTokens.Start), XmlTokens.DateTimeFormat, CultureInfo.InvariantCulture);
             builder.PathConstraint = xml.Attribute(XmlTokens.PathConstraint)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExplorationIteration), XmlTokens.PathConstraint);
 
-            builder.Exception = xml.Attribute(XmlTokens.Exception)?.Value ?? string.Empty;
+            string? exceptionType = xml.Attribute(XmlTokens.Exception)?.Value;
+            if (exceptionType != null) 
+            {
+                TypeSig exception = _typeParser.Parse(exceptionType);
+                builder.Exception = exception;
+            }
+
             builder.StandardOutput = xml.Attribute(XmlTokens.StandardOutput)?.Value ?? string.Empty;
             builder.ErrorOutput = xml.Attribute(XmlTokens.ErrorOutput)?.Value ?? string.Empty;
 

--- a/dnWalker.Explorations/Xml/XmlExplorationDeserializer.cs
+++ b/dnWalker.Explorations/Xml/XmlExplorationDeserializer.cs
@@ -36,13 +36,13 @@ namespace dnWalker.Explorations.Xml
 
             builder.AssemblyName = xml.Attribute(XmlTokens.AssemblyName)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExploration), XmlTokens.AssemblyName);
             builder.AssemblyFileName = xml.Attribute(XmlTokens.AssemblyFileName)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExploration), XmlTokens.AssemblyFileName);
-            builder.MethodSignature = xml.Attribute(XmlTokens.MethodSignature)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExploration), XmlTokens.MethodSignature);
+            string methodSignature = xml.Attribute(XmlTokens.MethodSignature)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExploration), XmlTokens.MethodSignature);
+            IMethod method = _methodParser.Parse(methodSignature);
+            builder.MethodUnderTest = method;
             builder.Solver = xml.Attribute(XmlTokens.Solver)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExploration), XmlTokens.Solver);
             builder.Start = DateTime.ParseExact(xml.Attribute(XmlTokens.Start)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExploration), XmlTokens.Start), XmlTokens.DateTimeFormat, CultureInfo.InvariantCulture);
             builder.End = DateTime.ParseExact(xml.Attribute(XmlTokens.End)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExploration), XmlTokens.Start), XmlTokens.DateTimeFormat, CultureInfo.InvariantCulture);
             builder.Failed = bool.Parse(xml.Attribute(XmlTokens.Failed)?.Value ?? throw new MissingAttributeException(nameof(ConcolicExploration), XmlTokens.Failed));
-
-            IMethod method = _methodParser.Parse(builder.MethodSignature);
 
             foreach (XElement iterationXml in xml.Elements(XmlTokens.Iteration))
             {

--- a/dnWalker.Explorations/Xml/XmlExplorationSerializer.cs
+++ b/dnWalker.Explorations/Xml/XmlExplorationSerializer.cs
@@ -26,7 +26,7 @@ namespace dnWalker.Explorations.Xml
             XElement xml = new XElement(Exploration);
             xml.SetAttributeValue(AssemblyName, exploration.AssemblyName);
             xml.SetAttributeValue(AssemblyFileName, exploration.AssemblyFileName);
-            xml.SetAttributeValue(MethodSignature, exploration.MethodSignature);
+            xml.SetAttributeValue(MethodSignature, exploration.MethodUnderTest);
             xml.SetAttributeValue(Solver, exploration.Solver);
             xml.SetAttributeValue(Start, exploration.Start.ToString(DateTimeFormat, CultureInfo.InvariantCulture));
             xml.SetAttributeValue(End, exploration.End.ToString(DateTimeFormat, CultureInfo.InvariantCulture));

--- a/dnWalker.Explorations/Xml/XmlExplorationSerializer.cs
+++ b/dnWalker.Explorations/Xml/XmlExplorationSerializer.cs
@@ -48,7 +48,7 @@ namespace dnWalker.Explorations.Xml
             xml.SetAttributeValue(Start, iteration.Start.ToString(DateTimeFormat, CultureInfo.InvariantCulture));
             xml.SetAttributeValue(End, iteration.End.ToString(DateTimeFormat, CultureInfo.InvariantCulture));
             xml.SetAttributeValue(PathConstraint, iteration.PathConstraint);
-            xml.SetAttributeValue(XmlTokens.Exception, iteration.Exception);
+            xml.SetAttributeValue(XmlTokens.Exception, iteration.Exception?.FullName);
             xml.SetAttributeValue(StandardOutput, iteration.StandardOutput);
             xml.SetAttributeValue(ErrorOutput, iteration.ErrorOutput);
 

--- a/dnWalker.TestGenerator/TestClasses/TestClassContext.Builder.cs
+++ b/dnWalker.TestGenerator/TestClasses/TestClassContext.Builder.cs
@@ -203,7 +203,7 @@ namespace dnWalker.TestGenerator.TestClasses
 
                 IMethodParser methodTranslator = new MethodParser(definitionProvider);
                 ITypeParser typeTranslator = new TypeParser(definitionProvider);
-                IMethod methodSignature = methodTranslator.Parse(exploration.MethodSignature);
+                IMethod methodSignature = exploration.MethodUnderTest;
 
                 foreach (ConcolicExplorationIteration iteration in exploration.Iterations)
                 {
@@ -217,7 +217,7 @@ namespace dnWalker.TestGenerator.TestClasses
                         OutputModel = iteration.OutputModel,
                         ErrorOutput = iteration.ErrorOutput ?? string.Empty,
                         StandardOutput = iteration.StandardOutput ?? string.Empty,
-                        Exception = string.IsNullOrWhiteSpace(iteration.Exception) ? null : typeTranslator.Parse(iteration.Exception),
+                        Exception = iteration.Exception,
                         PathConstraint = iteration.PathConstraint ?? string.Empty,
                     };
 


### PR DESCRIPTION
Použití MethodDef a TypeSig místo jejich string reprezentace. Také je přidaná konverze ExplorationResult (výstup z IExplorer.Run(), obsahuje interní objekty) na ConcolicExploration (transfer mezi konkolickou exekucí a generováním testů)