### PR TITLE
dependency heap graph building moved to dnWalker.Symbolic

### DIFF
--- a/dnWalker.Symbolic.Tests/Heap/Graphs/HeapGraphTests.cs
+++ b/dnWalker.Symbolic.Tests/Heap/Graphs/HeapGraphTests.cs
@@ -2,7 +2,7 @@
 
 using dnWalker.Symbolic;
 using dnWalker.Symbolic.Heap;
-using dnWalker.TestGenerator.Symbolic.Heap;
+using dnWalker.Symbolic.Heap.Graphs;
 
 using FluentAssertions;
 
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 using Xunit;
 
-namespace dnWalker.TestGenerator.Tests.Heap
+namespace dnWalker.Symbolic.Tests.Heap.Graphs
 {
 
     public class HeapGraphTests

--- a/dnWalker.Symbolic/Heap/Graphs/DependencyGroup.cs
+++ b/dnWalker.Symbolic/Heap/Graphs/DependencyGroup.cs
@@ -1,13 +1,11 @@
-﻿using dnWalker.Symbolic.Heap;
-
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace dnWalker.TestGenerator.Symbolic.Heap
+namespace dnWalker.Symbolic.Heap.Graphs
 {
     public class DependencyGroup : IReadOnlyCollection<IReadOnlyHeapNode>
     {
@@ -16,7 +14,7 @@ namespace dnWalker.TestGenerator.Symbolic.Heap
         public DependencyGroup(IEnumerable<IReadOnlyHeapNode> heapNodes)
         {
             _heapNodes = new List<IReadOnlyHeapNode>(heapNodes);
-            
+
             // nodes within one group have proper ordering
             _heapNodes.Sort(static (n1, n2) => n1.Location.Value.CompareTo(n2.Location.Value));
         }

--- a/dnWalker.Symbolic/Heap/Graphs/HeapEdge.cs
+++ b/dnWalker.Symbolic/Heap/Graphs/HeapEdge.cs
@@ -1,6 +1,4 @@
-﻿using dnWalker.Symbolic;
-
-using QuikGraph;
+﻿using QuikGraph;
 
 using System;
 using System.Collections.Generic;
@@ -9,7 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace dnWalker.TestGenerator.Symbolic.Heap
+namespace dnWalker.Symbolic.Heap.Graphs
 {
     public enum HeapEdgeType
     {
@@ -22,7 +20,7 @@ namespace dnWalker.TestGenerator.Symbolic.Heap
     {
         private readonly HeapEdgeType _type;
 
-        public HeapEdge([NotNull]Location source, [NotNull] Location target, HeapEdgeType type) : base(source, target)
+        public HeapEdge([NotNull] Location source, [NotNull] Location target, HeapEdgeType type) : base(source, target)
         {
             _type = type;
         }

--- a/dnWalker.Symbolic/Heap/Graphs/HeapExtensions.cs
+++ b/dnWalker.Symbolic/Heap/Graphs/HeapExtensions.cs
@@ -1,8 +1,5 @@
 ﻿using dnlib.DotNet;
 
-using dnWalker.Symbolic;
-using dnWalker.Symbolic.Heap;
-
 using QuikGraph;
 
 using System;
@@ -11,7 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace dnWalker.TestGenerator.Symbolic.Heap
+namespace dnWalker.Symbolic.Heap.Graphs
 {
     public static class HeapExtensions
     {
@@ -45,7 +42,7 @@ namespace dnWalker.TestGenerator.Symbolic.Heap
             if (objectNode.HasFields)
             {
                 Location target = objectNode.Location;
-                foreach (IField field in objectNode.Fields)
+                foreach (var field in objectNode.Fields)
                 {
                     IValue value = objectNode.GetFieldOrDefault(field);
                     if (value is Location source && source != Location.Null)
@@ -59,7 +56,7 @@ namespace dnWalker.TestGenerator.Symbolic.Heap
             if (objectNode.HasMethodInvocations)
             {
                 Location target = objectNode.Location;
-                foreach ((IMethod method, int invocation) in objectNode.MethodInvocations)
+                foreach ((IMethod? method, int invocation) in objectNode.MethodInvocations)
                 {
                     IValue value = objectNode.GetMethodResult(method, invocation);
                     if (value is Location source && source != Location.Null)

--- a/dnWalker.Symbolic/Heap/Graphs/HeapGraph.cs
+++ b/dnWalker.Symbolic/Heap/Graphs/HeapGraph.cs
@@ -6,14 +6,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using dnWalker.Symbolic;
-using dnWalker.Symbolic.Heap;
-
 using QuikGraph.Algorithms;
 using QuikGraph.Algorithms.ConnectedComponents;
 using QuikGraph.Algorithms.TopologicalSort;
 
-namespace dnWalker.TestGenerator.Symbolic.Heap
+namespace dnWalker.Symbolic.Heap.Graphs
 {
     public class HeapGraph : IBidirectionalGraph<Location, HeapEdge>
     {
@@ -35,7 +32,7 @@ namespace dnWalker.TestGenerator.Symbolic.Heap
             {
                 // condensate the graph:
                 // 1) find condensation (SSCs)
-                var sccAlg = new StronglyConnectedComponentsAlgorithm<Location, HeapEdge>(this);
+                StronglyConnectedComponentsAlgorithm<Location, HeapEdge> sccAlg = new StronglyConnectedComponentsAlgorithm<Location, HeapEdge>(this);
                 sccAlg.Compute();
                 int componentCount = sccAlg.ComponentCount;
                 IDictionary<Location, int> components = sccAlg.Components;
@@ -53,7 +50,7 @@ namespace dnWalker.TestGenerator.Symbolic.Heap
 
                 DependencyGroup[] groups = Build(groupBuilders, _heap);
 
-                var depGraph = new AdjacencyGraph<DependencyGroup, Edge<DependencyGroup>>(false, groups.Length);
+                AdjacencyGraph<DependencyGroup, Edge<DependencyGroup>> depGraph = new AdjacencyGraph<DependencyGroup, Edge<DependencyGroup>>(false, groups.Length);
                 depGraph.AddVertexRange(groups);
 
                 // 2) build edges between the SSCs

--- a/dnWalker.Symbolic/dnWalker.Symbolic.csproj
+++ b/dnWalker.Symbolic/dnWalker.Symbolic.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="dnlib" Version="3.5.0" />
+    <PackageReference Include="QuikGraph" Version="2.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dnWalker.TestGenerator/Templates/ArrangeTemplateBase.cs
+++ b/dnWalker.TestGenerator/Templates/ArrangeTemplateBase.cs
@@ -1,5 +1,6 @@
 ﻿using dnWalker.Symbolic;
 using dnWalker.Symbolic.Heap;
+using dnWalker.Symbolic.Heap.Graphs;
 using dnWalker.Symbolic.Variables;
 
 using System;
@@ -9,7 +10,6 @@ using System.Diagnostics;
 using System.Linq;
 
 using dnlib.DotNet;
-using dnWalker.TestGenerator.Symbolic.Heap;
 
 namespace dnWalker.TestGenerator.Templates
 {

--- a/dnWalker.TestGenerator/dnWalker.TestGenerator.csproj
+++ b/dnWalker.TestGenerator/dnWalker.TestGenerator.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="QuikGraph" Version="2.5.0" />
     <PackageReference Include="System.CodeDom" Version="7.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Výroba grafu závislosti nad haldou byla implementována v komponentě dnWalker.TestGenerator, Zde je přesunuta do sdílené knihovny dnWalker.Symbolic, aby ji bylo možné použít v jiných komponentách