### PR TITLE
act, arrange primitive tests

### DIFF
--- a/dnWalker.TestWriter.Tests/Generators/Act/SimpleActPrimitivesTests.cs
+++ b/dnWalker.TestWriter.Tests/Generators/Act/SimpleActPrimitivesTests.cs
@@ -1,0 +1,178 @@
+﻿using dnlib.DotNet;
+
+using dnWalker.TestUtils;
+using dnWalker.TestWriter.Generators;
+using dnWalker.TestWriter.Generators.Act;
+using dnWalker.TestWriter.Tests.Generators.Schemas;
+
+using FluentAssertions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit.Abstractions;
+
+namespace dnWalker.TestWriter.Tests.Generators.Act
+{
+    file class TestClass
+    {
+        public static int StaticMethod(int x, int y) => 0;
+        public int InstanceMethod(int x, int y) => 0;
+    }
+
+    public class SimpleActPrimitivesTests : TestSchemaTestBase
+    {
+        public SimpleActPrimitivesTests(ITestOutputHelper textOutput) : base(textOutput)
+        {
+        }
+
+        [Fact]
+        public void TestActStaticNoReturnSymbol()
+        {
+            MethodDef method = GetMethod(typeof(TestClass), nameof(TestClass.StaticMethod));
+
+            string expected =
+            $"""
+            {method.DeclaringType!.Name}.StaticMethod(x, y);
+            """;
+
+            SimpleActWriter actWriter = new SimpleActWriter();
+            Writer writer = new Writer();
+
+            actWriter.TryWriteAct(GetTestContext(method), writer, null).Should().BeTrue();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+
+        [Fact]
+        public void TestActStaticWithReturnSymbol()
+        {
+            MethodDef method = GetMethod(typeof(TestClass), nameof(TestClass.StaticMethod));
+
+            string expected =
+            $"""
+            int result = {method.DeclaringType!.Name}.StaticMethod(x, y);
+            """;
+
+            SimpleActWriter actWriter = new SimpleActWriter();
+            Writer writer = new Writer();
+
+            actWriter.TryWriteAct(GetTestContext(method), writer, "result").Should().BeTrue();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+
+        [Fact]
+        public void TestActInstanceNoReturnSymbol()
+        {
+            MethodDef method = GetMethod(typeof(TestClass), nameof(TestClass.InstanceMethod));
+
+            string expected =
+            $"""
+            @this.InstanceMethod(x, y);
+            """;
+
+            SimpleActWriter actWriter = new SimpleActWriter();
+            Writer writer = new Writer();
+
+            actWriter.TryWriteAct(GetTestContext(method), writer, null).Should().BeTrue();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+
+        [Fact]
+        public void TestActInstanceWithReturnSymbol()
+        {
+            MethodDef method = GetMethod(typeof(TestClass), nameof(TestClass.InstanceMethod));
+
+            string expected =
+            $"""
+            int result = @this.InstanceMethod(x, y);
+            """;
+
+            SimpleActWriter actWriter = new SimpleActWriter();
+            Writer writer = new Writer();
+
+            actWriter.TryWriteAct(GetTestContext(method), writer, "result").Should().BeTrue();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+
+        [Fact]
+        public void TestActDelegateStaticNoReturnSymbol()
+        {
+            MethodDef method = GetMethod(typeof(TestClass), nameof(TestClass.StaticMethod));
+
+            string expected =
+            $$"""
+            Action act = () => {{method.DeclaringType!.Name}}.StaticMethod(x, y);
+            """;
+
+            SimpleActWriter actWriter = new SimpleActWriter();
+            Writer writer = new Writer();
+
+            actWriter.TryWriteActDelegate(GetTestContext(method), writer, null, "act").Should().BeTrue();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+
+        [Fact]
+        public void TestActDelegateStaticWithReturnSymbol()
+        {
+            MethodDef method = GetMethod(typeof(TestClass), nameof(TestClass.StaticMethod));
+
+            string expected =
+            $$"""
+            int result = 0;
+            Action act = () => { result = {{ method.DeclaringType!.Name }}.StaticMethod(x, y); };
+            """;
+
+            SimpleActWriter actWriter = new SimpleActWriter();
+            Writer writer = new Writer();
+
+            actWriter.TryWriteActDelegate(GetTestContext(method), writer, "result", "act").Should().BeTrue();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+
+        [Fact]
+        public void TestActDelegateInstanceNoReturnSymbol()
+        {
+            MethodDef method = GetMethod(typeof(TestClass), nameof(TestClass.InstanceMethod));
+
+            string expected =
+            """
+            Action act = () => @this.InstanceMethod(x, y);
+            """;
+
+            SimpleActWriter actWriter = new SimpleActWriter();
+            Writer writer = new Writer();
+
+            actWriter.TryWriteActDelegate(GetTestContext(method), writer, null, "act").Should().BeTrue();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+
+        [Fact]
+        public void TestActDelegateInstanceWithReturnSymbol()
+        {
+            MethodDef method = GetMethod(typeof(TestClass), nameof(TestClass.InstanceMethod));
+
+            string expected =
+            """
+            int result = 0;
+            Action act = () => { result = @this.InstanceMethod(x, y); };
+            """;
+
+            SimpleActWriter actWriter = new SimpleActWriter();
+            Writer writer = new Writer();
+
+            actWriter.TryWriteActDelegate(GetTestContext(method), writer, "result", "act").Should().BeTrue();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+    }
+}

--- a/dnWalker.TestWriter.Tests/Generators/Arrange/ArrangerTests.cs
+++ b/dnWalker.TestWriter.Tests/Generators/Arrange/ArrangerTests.cs
@@ -1,0 +1,345 @@
+﻿using dnlib.DotNet;
+
+using dnWalker.Symbolic;
+using dnWalker.Symbolic.Heap;
+using dnWalker.Symbolic.Variables;
+using dnWalker.TestWriter.Generators;
+using dnWalker.TestWriter.Generators.Arrange;
+using dnWalker.TestWriter.Tests.Generators.Schemas;
+
+using FluentAssertions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit.Abstractions;
+
+namespace dnWalker.TestWriter.Tests.Generators.Arrange
+{
+    file class TestClass
+    {
+        public TestClass ReturnSelf(int x)
+        {
+            return this;
+        }
+
+        public TestClass? Next;
+
+        public static string? StaticField;
+
+        private static string? PrivateStaticField;
+
+        public int ValueField;
+        public readonly int ConstValueField;
+
+        private int _valueField;
+        private readonly int _constValueField;
+
+        public int[]? ArrayField;
+
+        public int MethodWithManyArgs(TestClass? tc1, TestClass? tc2, string? str)
+        {
+            return ValueField + (ArrayField?.Length ?? 0) + (tc1?.ValueField ?? 0) + (tc2?.ValueField ?? 0) - (str?.Length ?? 0);
+        }
+
+        public virtual int VirtualMethod()
+        {
+            return 0;
+        }
+    }
+
+    public class ArrangerTests : TestSchemaTestBase
+    {
+        public ArrangerTests(ITestOutputHelper textOutput) : base(textOutput)
+        {
+        }
+
+        [Fact]
+        public void TestArrangeMethodArgs()
+        {
+            TypeDef td = GetType(typeof(TestClass));
+            MethodDef md = GetMethod(typeof(TestClass), nameof(TestClass.MethodWithManyArgs));
+
+            string expected =
+            $"""
+            // Arrange method arguments
+            {td.Name} @this = {td.Name}1;
+            {td.Name} tc1 = {td.Name}1;
+            {td.Name} tc2 = null;
+            string str = "hello world";
+            """;
+
+            IModel input = NewModel();
+            IHeapInfo heap = input.HeapInfo;
+
+            IObjectHeapNode thisNode = heap.InitializeObject(td.ToTypeSig());
+            
+
+            input.SetValue(new MethodArgumentVariable(md.Parameters[0]), thisNode.Location);
+            input.SetValue(new MethodArgumentVariable(md.Parameters[1]), thisNode.Location);
+            //input.SetValue(new MethodArgumentVariable(md.Parameters[2]), Location.Null);
+            input.SetValue(new MethodArgumentVariable(md.Parameters[3]), new StringValue("hello world"));
+
+            ITestContext testContext = GetTestContext(md, b => { b.InputModel = input; b.OutputModel = input.Clone(); });
+
+            Writer writer = new Writer();
+
+            Arranger arranger = new Arranger(TestTemplate, testContext, writer);
+
+            arranger.WriteArrangeMethodArguments();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+
+        [Fact]
+        public void TestArrangePublicStaticFields()
+        {
+            TypeDef td = GetType(typeof(TestClass));
+            MethodDef md = GetMethod(typeof(TestClass), nameof(TestClass.MethodWithManyArgs));
+
+            string expected =
+            $"""
+            // Arrange static fields
+            {td.Name}.StaticField = "a string";
+            """;
+
+            IModel input = NewModel();
+            input.SetValue(new StaticFieldVariable(td.FindField("StaticField")), new StringValue("a string"));
+
+            ITestContext testContext = GetTestContext(md, b => { b.InputModel = input; b.OutputModel = input.Clone(); });
+
+            Writer writer = new Writer();
+
+            Arranger arranger = new Arranger(TestTemplate, testContext, writer);
+
+            arranger.WriteArrangeStaticFields();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+
+        [Fact]
+        public void TestArrangePrivateStaticFields()
+        {
+            TypeDef td = GetType(typeof(TestClass));
+            MethodDef md = GetMethod(typeof(TestClass), nameof(TestClass.MethodWithManyArgs));
+
+            string expected =
+            $"""
+            // Arrange static fields
+            typeof({td.Name}).GetField("PrivateStaticField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static).SetValue(null, "a string");
+            """;
+
+            IModel input = NewModel();
+            input.SetValue(new StaticFieldVariable(td.FindField("PrivateStaticField")), new StringValue("a string"));
+
+            ITestContext testContext = GetTestContext(md, b => { b.InputModel = input; b.OutputModel = input.Clone(); });
+
+            Writer writer = new Writer();
+
+            Arranger arranger = new Arranger(TestTemplate, testContext, writer);
+
+            arranger.WriteArrangeStaticFields();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+
+        [Fact]
+        public void TestArrangePrivateField()
+        {
+            TypeDef td = GetType(typeof(TestClass));
+            MethodDef md = GetMethod(typeof(TestClass), nameof(TestClass.MethodWithManyArgs));
+
+            string expected =
+            $"""
+            // Arrange input model heap
+            {td.Name} {td.Name}1 = new {td.Name}();
+            typeof({td.Name}).GetField("_valueField", System.Reflection.BindingFlags.NonPublic).SetValue({td.Name}1, 5);
+            """;
+
+            IModel input = NewModel();
+            IObjectHeapNode thisNode = input.HeapInfo.InitializeObject(td.ToTypeSig());
+            thisNode.SetField(td.FindField("_valueField"), new PrimitiveValue<int>(5));
+
+            input.SetValue(new MethodArgumentVariable(md.Parameters[0]), thisNode.Location);
+
+            ITestContext testContext = GetTestContext(md, b => { b.InputModel = input; b.OutputModel = input.Clone(); });
+
+            Writer writer = new Writer();
+
+            Arranger arranger = new Arranger(TestTemplate, testContext, writer);
+
+            arranger.WriteArrangeHeap();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+
+        [Fact]
+        public void TestArrangePrivateReadonlyField()
+        {
+            TypeDef td = GetType(typeof(TestClass));
+            MethodDef md = GetMethod(typeof(TestClass), nameof(TestClass.MethodWithManyArgs));
+
+            string expected =
+            $"""
+            // Arrange input model heap
+            {td.Name} {td.Name}1 = new {td.Name}();
+            typeof({td.Name}).GetField("_constValueField", System.Reflection.BindingFlags.NonPublic).SetValue({td.Name}1, 5);
+            """;
+
+            IModel input = NewModel();
+            IObjectHeapNode thisNode = input.HeapInfo.InitializeObject(td.ToTypeSig());
+            thisNode.SetField(td.FindField("_constValueField"), new PrimitiveValue<int>(5));
+
+            input.SetValue(new MethodArgumentVariable(md.Parameters[0]), thisNode.Location);
+
+            ITestContext testContext = GetTestContext(md, b => { b.InputModel = input; b.OutputModel = input.Clone(); });
+
+            Writer writer = new Writer();
+
+            Arranger arranger = new Arranger(TestTemplate, testContext, writer);
+
+            arranger.WriteArrangeHeap();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+
+        [Fact]
+        public void TestArrangePublicField()
+        {
+            TypeDef td = GetType(typeof(TestClass));
+            MethodDef md = GetMethod(typeof(TestClass), nameof(TestClass.MethodWithManyArgs));
+
+            string expected =
+            $"""
+            // Arrange input model heap
+            {td.Name} {td.Name}1 = new {td.Name}();
+            {td.Name}1.ValueField = 5;
+            """;
+
+            IModel input = NewModel();
+            IObjectHeapNode thisNode = input.HeapInfo.InitializeObject(td.ToTypeSig());
+            thisNode.SetField(td.FindField("ValueField"), new PrimitiveValue<int>(5));
+
+            input.SetValue(new MethodArgumentVariable(md.Parameters[0]), thisNode.Location);
+
+            ITestContext testContext = GetTestContext(md, b => { b.InputModel = input; b.OutputModel = input.Clone(); });
+
+            Writer writer = new Writer();
+
+            Arranger arranger = new Arranger(TestTemplate, testContext, writer);
+
+            arranger.WriteArrangeHeap();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+
+        [Fact]
+        public void TestArrangePublicReadonlyField()
+        {
+            TypeDef td = GetType(typeof(TestClass));
+            MethodDef md = GetMethod(typeof(TestClass), nameof(TestClass.MethodWithManyArgs));
+
+            string expected =
+            $"""
+            // Arrange input model heap
+            {td.Name} {td.Name}1 = new {td.Name}();
+            typeof({td.Name}).GetField("ConstValueField", System.Reflection.BindingFlags.Public).SetValue({td.Name}1, 5);
+            """;
+
+            IModel input = NewModel();
+            IObjectHeapNode thisNode = input.HeapInfo.InitializeObject(td.ToTypeSig());
+            thisNode.SetField(td.FindField("ConstValueField"), new PrimitiveValue<int>(5));
+
+            input.SetValue(new MethodArgumentVariable(md.Parameters[0]), thisNode.Location);
+
+            ITestContext testContext = GetTestContext(md, b => { b.InputModel = input; b.OutputModel = input.Clone(); });
+
+            Writer writer = new Writer();
+
+            Arranger arranger = new Arranger(TestTemplate, testContext, writer);
+
+            arranger.WriteArrangeHeap();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+
+        [Fact]
+        public void TestArrangeNonCylicHeap()
+        {
+            TypeDef td = GetType(typeof(TestClass));
+            MethodDef md = GetMethod(typeof(TestClass), nameof(TestClass.MethodWithManyArgs));
+
+            // some arguments will be dependent on each other
+
+            string expected =
+            $"""
+            // Arrange input model heap
+            {td.Name} {td.Name}1 = new {td.Name}();
+            {td.Name} {td.Name}2 = new {td.Name}();
+            {td.Name}2.Next = {td.Name}1;
+            """;
+
+
+            IModel input = NewModel();
+            IObjectHeapNode nextNode = input.HeapInfo.InitializeObject(td.ToTypeSig());
+            IObjectHeapNode thisNode = input.HeapInfo.InitializeObject(td.ToTypeSig());
+            thisNode.SetField(td.FindField("Next"), nextNode.Location);
+
+            input.SetValue(new MethodArgumentVariable(md.Parameters[0]), thisNode.Location);
+
+            ITestContext testContext = GetTestContext(md, b => { b.InputModel = input; b.OutputModel = input.Clone(); });
+
+            Writer writer = new Writer();
+
+            Arranger arranger = new Arranger(TestTemplate, testContext, writer);
+
+            arranger.WriteArrangeHeap();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+
+        [Fact]
+        public void TestArrangeCylicHeap()
+        {
+            TypeDef td = GetType(typeof(TestClass));
+            MethodDef md = GetMethod(typeof(TestClass), nameof(TestClass.MethodWithManyArgs));
+
+            // some arguments will be dependent on each other
+
+            string expected =
+            $"""
+            // Arrange input model heap
+            {td.Name} {td.Name}1 = new {td.Name}();
+            {td.Name} {td.Name}2 = new {td.Name}();
+            {td.Name} {td.Name}3 = new {td.Name}();
+            {td.Name}1.Next = {td.Name}2;
+            {td.Name}2.Next = {td.Name}3;
+            {td.Name}3.Next = {td.Name}1;
+            """;
+
+
+            IModel input = NewModel();
+            IObjectHeapNode node1 = input.HeapInfo.InitializeObject(td.ToTypeSig());
+            IObjectHeapNode node2 = input.HeapInfo.InitializeObject(td.ToTypeSig());
+            IObjectHeapNode node3 = input.HeapInfo.InitializeObject(td.ToTypeSig());
+            node1.SetField(td.FindField("Next"), node2.Location);
+            node2.SetField(td.FindField("Next"), node3.Location);
+            node3.SetField(td.FindField("Next"), node1.Location);
+
+            input.SetValue(new MethodArgumentVariable(md.Parameters[0]), node1.Location);
+
+            ITestContext testContext = GetTestContext(md, b => { b.InputModel = input; b.OutputModel = input.Clone(); });
+
+            Writer writer = new Writer();
+
+            Arranger arranger = new Arranger(TestTemplate, testContext, writer);
+
+            arranger.WriteArrangeHeap();
+
+            writer.ToString().Trim().Should().Be(expected);
+        }
+    }
+}

--- a/dnWalker.TestWriter.Tests/Generators/Schemas/TestSchemaTestBase.cs
+++ b/dnWalker.TestWriter.Tests/Generators/Schemas/TestSchemaTestBase.cs
@@ -1,0 +1,92 @@
+﻿using dnlib.DotNet;
+
+using dnWalker.Explorations;
+using dnWalker.Symbolic;
+using dnWalker.TestUtils;
+using dnWalker.TestWriter.Generators;
+using dnWalker.TestWriter.Generators.Act;
+using dnWalker.TestWriter.Generators.Arrange;
+using dnWalker.TestWriter.Generators.Assert;
+using dnWalker.TestWriter.Moq;
+using dnWalker.TestWriter.Xunit;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit.Abstractions;
+
+namespace dnWalker.TestWriter.Tests.Generators.Schemas
+{
+    public abstract class TestSchemaTestBase : DnlibTestBase<TestSchemaTestBase>
+    {
+        protected TestSchemaTestBase(ITestOutputHelper textOutput) : base(textOutput)
+        {
+        }
+
+        protected IReadOnlyModel EmptyModel
+        {
+            get;
+        } = new Model();
+
+        protected IModel NewModel()
+        {
+            return new Model();
+        }
+
+        protected ITestTemplate GetTestTemplate()
+        {
+            return new TestTemplate(
+                new IArrangePrimitives[]
+                {
+                    new MoqArrange(),
+                    new SimpleArrangePrimitives()
+                },
+                new IActPrimitives[]
+                {
+                    new SimpleActWriter(),
+                },
+                new IAssertPrimitives[]
+                {
+                    new XunitAssertions(),
+                    new SimpleAssertPrimitives()
+                });
+        }
+
+        protected ConcolicExplorationIteration GetIteration(IMethod method, Action<ConcolicExplorationIteration.Builder>? initialize = null)
+        {
+            return GetIteration(builder =>
+            {
+                builder.MethodUnderTest = method;
+                builder.AssemblyFileName = "DUMMY";
+                builder.AssemblyName = "DUMMY";
+                builder.Failed = false;
+                builder.Solver = "DUMMY";
+            }, initialize);
+        }
+
+        protected ConcolicExplorationIteration GetIteration(Action<ConcolicExploration.Builder> initializeExploration, Action<ConcolicExplorationIteration.Builder>? initialize = null)
+        {
+            ConcolicExploration.Builder builder = new ConcolicExploration.Builder();
+            initializeExploration(builder);
+            ConcolicExplorationIteration.Builder itBuilder = new ConcolicExplorationIteration.Builder()
+            {
+                StandardOutput = string.Empty,
+                ErrorOutput = string.Empty,
+                PathConstraint = "DUMMY",
+                IterationNumber = 0,
+                InputModel = EmptyModel,
+                OutputModel = EmptyModel,
+            };
+
+
+
+            builder.Iterations.Add(itBuilder);
+            initialize?.Invoke(itBuilder);
+
+            return builder.Build().Iterations[0];
+        }
+    }
+}

--- a/dnWalker.TestWriter/Generators/Act/SimpleActPrimitives.cs
+++ b/dnWalker.TestWriter/Generators/Act/SimpleActPrimitives.cs
@@ -18,19 +18,16 @@ namespace dnWalker.TestWriter.Generators.Act
 
             if (returnSymbol != null && method.HasReturnType)
             {
-                output.Write($"{method.ReturnType.GetNameOrAlias()} returnSymbol = ");
+                output.Write($"{method.ReturnType.GetNameOrAlias()} {returnSymbol} = ");
             }
-
+            
+            if (method.IsStatic)
+            {
+                WriteStaticMethod(context, output, method);
+            }
             else
             {
-                if (method.IsStatic)
-                {
-                    WriteStaticMethod(context, output, method);
-                }
-                else
-                {
-                    WriteInstanceMethod(context, output, method);
-                }
+                WriteInstanceMethod(context, output, method);
             }
 
             output.WriteLine(";");
@@ -44,15 +41,19 @@ namespace dnWalker.TestWriter.Generators.Act
 
             if (returnSymbol != null && method.HasReturnType)
             {
-                output.Write($"{method.ReturnType.GetNameOrAlias()} {returnSymbol} = {context.GetDefaultLiteral(method.ReturnType)};");
+                output.WriteLine($"{method.ReturnType.GetNameOrAlias()} {returnSymbol} = {context.GetDefaultLiteral(method.ReturnType)};");
                 output.Write($"Action {delegateSymbol} = () => {{ {returnSymbol} = ");
 
                 if (method.IsStatic)
                 {
                     WriteStaticMethod(context, output, method);
                 }
+                else
+                {
+                    WriteInstanceMethod(context, output, method);
+                }
 
-                output.WriteLine($"}};");
+                output.WriteLine($"; }};");
             }
             else
             {
@@ -61,6 +62,10 @@ namespace dnWalker.TestWriter.Generators.Act
                 if (method.IsStatic)
                 {
                     WriteStaticMethod(context, output, method);
+                }
+                else
+                {
+                    WriteInstanceMethod(context, output, method);
                 }
 
                 output.WriteLine(";");

--- a/dnWalker.TestWriter/Generators/Arrange/SimpleArrangePrimitives.cs
+++ b/dnWalker.TestWriter/Generators/Arrange/SimpleArrangePrimitives.cs
@@ -80,13 +80,13 @@ namespace dnWalker.TestWriter.Generators.Arrange
             string bindingFlags = (field.IsPublic, field.IsStatic) switch
             {
                 (true, false) => PublicInstanceFlags,
-                (false, false) => PublicInstanceFlags,
+                (false, false) => NonPublicInstanceFlags,
                 (true, true) => PublicStaticFlags,
-                (false, true) => PublicStaticFlags,
+                (false, true) => NonPublicStaticFlags,
             };
 
-            string typeName = testContext.GetSymbolContext(symbol).Type.GetNameOrAlias();
-            output.WriteLine($"typeof({typeName}).GetField(\"{field.Name}\", {bindingFlags}).SetValue({symbol}, {literal})");
+            string typeName = field.DeclaringType!.ToTypeSig().GetNameOrAlias();
+            output.WriteLine($"typeof({typeName}).GetField(\"{field.Name}\", {bindingFlags}).SetValue({symbol}, {literal});");
         }
 
         public bool TryWriteArrangeInitializeMethod(ITestContext testContext, IWriter output, string symbol, IMethod method, params string[] literals)

--- a/dnWalker.TestWriter/Generators/TestContextExtensions.cs
+++ b/dnWalker.TestWriter/Generators/TestContextExtensions.cs
@@ -82,7 +82,11 @@ namespace dnWalker.TestWriter.Generators
 
         public static string GetDefaultLiteral(this ITestContext context, TypeSig type)
         {
-            return $"default({type.GetNameOrAlias()})";
+            if (type.IsNumber()) return "0";
+            if (type.IsChar()) return "'\0'";
+            if (type.IsBoolean()) return "false";
+            if (type.GetIsValueType()) return $"default({type.GetNameOrAlias()})";
+            else return "null";
         }
 
         public static string? GetLiteral(this ITestContext context, IValue value)
@@ -90,7 +94,7 @@ namespace dnWalker.TestWriter.Generators
             return value switch
             {
                 Location l => l == Location.Null ? "null" : context.GetSymbolContext(l)?.Literal,
-                StringValue s => s == StringValue.Null ? "null" : $"{s.Content}",
+                StringValue s => s == StringValue.Null ? "null" : $"\"{s.Content}\"",
                 _ => value.ToString()
             };
         }

--- a/dnWalker.TestWriter/Generators/TestTemplateExtensions.cs
+++ b/dnWalker.TestWriter/Generators/TestTemplateExtensions.cs
@@ -1,4 +1,6 @@
-﻿using dnWalker.TestWriter.Generators.Arrange;
+﻿using dnlib.DotNet;
+
+using dnWalker.TestWriter.Generators.Arrange;
 
 using System;
 using System.Collections.Generic;
@@ -23,12 +25,47 @@ namespace dnWalker.TestWriter.Generators
             }
         }
 
+        #region Arrange
         public static void WriteArrange(this ITestTemplate testTemplate, ITestContext testContext, IWriter output)
         {
-            Arranger arranger = new Arranger(testTemplate.ArrangeWriters, testContext, output);
-            arranger.Run();
+            Arranger arranger = new Arranger(testTemplate, testContext, output);
+            arranger.WriteArrangeHeap();
+            arranger.WriteArrangeStaticFields();
+            arranger.WriteArrangeMethodArguments();
         }
 
+        public static void WriteArrangeCreateInstance(this ITestTemplate testTemplate, ITestContext testContext, IWriter output, string symbol)
+        {
+            ExecutePrimitiveOrThrow(testTemplate.ArrangeWriters, a => a.TryWriteArrangeCreateInstance(testContext, output, symbol));
+        }
+
+        public static void WriteArrangeInitializeField(this ITestTemplate testTemplate, ITestContext testContext, IWriter output, string symbol, IField field, string literal)
+        {
+            ExecutePrimitiveOrThrow(testTemplate.ArrangeWriters, a => a.TryWriteArrangeInitializeField(testContext, output, symbol, field, literal));
+        }
+
+        public static void WriteArrangeInitializeStaticField(this ITestTemplate testTemplate, ITestContext testContext, IWriter output, IField field, string literal)
+        {
+            ExecutePrimitiveOrThrow(testTemplate.ArrangeWriters, a => a.TryWriteArrangeInitializeStaticField(testContext, output, field, literal));
+        }
+
+        public static void WriteArrangeInitializeMethod(this ITestTemplate testTemplate, ITestContext testContext, IWriter output, string symbol, IMethod method, params string[] literals)
+        {
+            ExecutePrimitiveOrThrow(testTemplate.ArrangeWriters, a => a.TryWriteArrangeInitializeMethod(testContext, output, symbol, method, literals));
+        }
+
+        public static void WriteArrangeInitializeStaticMethod(this ITestTemplate testTemplate, ITestContext testContext, IWriter output, IMethod method, params string[] literals)
+        {
+            ExecutePrimitiveOrThrow(testTemplate.ArrangeWriters, a => a.TryWriteArrangeInitializeStaticMethod(testContext, output, method, literals));
+        }
+
+        public static void WriteArrangeInitializeArrayElement(this ITestTemplate testTemplate, ITestContext testContext, IWriter output, string symbol, int index, string literal)
+        {
+            ExecutePrimitiveOrThrow(testTemplate.ArrangeWriters, a => a.TryWriteArrangeInitializeArrayElement(testContext, output, symbol, index, literal));
+        }
+        #endregion Assert
+
+        #region Act
         public static void WriteAct(this ITestTemplate testTemplate, ITestContext testContext, IWriter output, string? returnSymbol = null)
         {
             ExecutePrimitiveOrThrow(testTemplate.ActWriters, act => act.TryWriteAct(testContext, output, returnSymbol), $"Failed to write 'act'");
@@ -38,8 +75,10 @@ namespace dnWalker.TestWriter.Generators
         {
             ExecutePrimitiveOrThrow(testTemplate.ActWriters, act => act.TryWriteActDelegate(testContext, output, returnSymbol, delegateSymbol), $"Failed to write 'act delegate'");
         }
+        #endregion Act
 
 
+        #region Assert
         public static void WriteAssertNull(this ITestTemplate testTemplate, ITestContext context, IWriter output, string symbol)
         {
             ExecutePrimitiveOrThrow(testTemplate.AssertWriters, assert => assert.TryWriteAssertNull(context, output, symbol), $"Failed to write 'assert null'");
@@ -102,5 +141,6 @@ namespace dnWalker.TestWriter.Generators
         {
             ExecutePrimitiveOrThrow(testTemplate.AssertWriters, assert => assert.TryWriteAssertNotOfType(context, output, objectSymbol, expectedType), $"Failed to write 'assert not of type'");
         }
+        #endregion Assert
     }
 }

--- a/dnWalker.TestWriter/Properties/AssemblyInfo.cs
+++ b/dnWalker.TestWriter/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("dnWalker.TestWriter.Tests")]
+


### PR DESCRIPTION
testy pro fallback implementaci IActPrimitives a IArrangePrimitives (obsažené v testech pro třídu Arranger), pro Arranger - řešení acylické a cyklické haldy